### PR TITLE
prepare v0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
+## 0.1.1
+
 <!-- release:start -->
+
+### Improvements
+
+- **npm README** — replaced symlink with a real file so the README renders correctly on the npm registry (#38)
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
 
 ## 0.1.0
 

--- a/packages/ai-cli/package.json
+++ b/packages/ai-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A tiny, agent-native CLI for generating images, video and text with dead-simple commands, stdin support and predictable artifact outputs",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Bump version to 0.1.1
- Add changelog entry for npm README fix

## Release notes

### Improvements

- **npm README** — replaced symlink with a real file so the README renders correctly on the npm registry (#38)