### PR TITLE
docs: fill documentation gaps across README, web, and SKILL.md

### DIFF
--- a/apps/web/docs/commands.mdx
+++ b/apps/web/docs/commands.mdx
@@ -184,6 +184,18 @@ See [Installation](/docs/installation#shell-completions) for setup instructions.
 
 ---
 
+## Timeouts
+
+Requests that exceed the per-command timeout are aborted automatically:
+
+| Command | Timeout |
+| --- | --- |
+| `text` | 120 seconds |
+| `image` | 120 seconds |
+| `video` | 300 seconds |
+
+Video generation uses a longer timeout because models typically need more processing time.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/apps/web/docs/models.mdx
+++ b/apps/web/docs/models.mdx
@@ -72,4 +72,7 @@ All models are accessed through [Vercel AI Gateway](https://vercel.com/docs/ai-g
   <Card title="Black Forest Labs" description="FLUX 2 Pro, FLUX Kontext" />
   <Card title="ByteDance" description="Seedance 2.0, Seedream 5.0" />
   <Card title="Kling AI" description="Kling v3.0" />
+  <Card title="Alibaba" description="Wan v2.5, Wan v2.6" />
+  <Card title="Recraft" description="Recraft v2, v3, v4" />
+  <Card title="Prodia" description="FLUX Fast Schnell" />
 </Cards>

--- a/apps/web/docs/single.mdx
+++ b/apps/web/docs/single.mdx
@@ -18,7 +18,17 @@ git diff | ai text "explain these changes"
 cat src/auth.ts | ai text "review for security issues"
 ```
 
-If both stdin and a prompt argument are provided, they're combined. If only stdin is provided, it becomes the full prompt.
+If both stdin and a prompt argument are provided, they're joined with a `---` separator:
+
+```
+<stdin content>
+
+---
+
+<prompt argument>
+```
+
+If only stdin is provided, it becomes the full prompt.
 
 ### Image
 

--- a/apps/web/docs/troubleshooting.mdx
+++ b/apps/web/docs/troubleshooting.mdx
@@ -1,0 +1,68 @@
+---
+title: Troubleshooting
+description: Common issues and how to resolve them.
+order: 8
+---
+
+## Missing API key
+
+```
+Error: No API key found
+```
+
+Set one of the following environment variables:
+
+```bash
+export AI_GATEWAY_API_KEY="your-key"   # recommended — access to all models
+export OPENAI_API_KEY="sk-..."         # OpenAI models only
+```
+
+Add the export to your shell profile (`~/.zshrc`, `~/.bashrc`) to persist across sessions.
+
+## Timeout errors
+
+Requests are aborted if they exceed the per-command timeout:
+
+| Command | Timeout |
+| --- | --- |
+| `text` | 120 seconds |
+| `image` | 120 seconds |
+| `video` | 300 seconds |
+
+If you're consistently hitting timeouts, try a faster model variant (e.g. `bytedance/seedance-2.0-fast` instead of `bytedance/seedance-2.0`).
+
+## `--quality` / `--style` warning
+
+```
+Warning: --quality and --style only apply to OpenAI models
+```
+
+The `--quality` and `--style` flags are OpenAI-specific provider options. They're silently ignored by other providers. Remove these flags when using non-OpenAI image models.
+
+## Version and upgrades
+
+Check your installed version:
+
+```bash
+ai --version
+```
+
+Upgrade to the latest release:
+
+```bash
+npm update -g ai-cli
+```
+
+## Gateway unreachable
+
+If the AI Gateway is unreachable, the `models` command falls back to a built-in list. Generation commands will fail if the gateway is required for routing.
+
+Check your network connection and verify the gateway status at [vercel.com/status](https://www.vercel.com/status).
+
+## No output / empty response
+
+If a command exits with code 0 but produces no visible output, it likely wrote to a file. Check stderr for the "Saved to" message, or use `--json` to see structured metadata including the output path:
+
+```bash
+ai image "a sunset" --json
+```

--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -40,6 +40,13 @@ All commands support:
 --json                   Output metadata as JSON
 ```
 
+Model IDs can be specified as `provider/model-name` or just `model-name` (resolved against the known model list):
+
+```bash
+ai text -m gpt-5.5 "hello"          # resolves to openai/gpt-5.5
+ai image -m flux-2-pro "a sunset"   # resolves to bfl/flux-2-pro
+```
+
 ### image
 
 ```
@@ -77,6 +84,16 @@ All commands support:
 
 All model types (text, image, video) are fetched live from the AI Gateway. If the gateway is unreachable, all model types fall back to a built-in list.
 
+### completions
+
+Output a shell completion script for tab completion of commands, flags, and model names:
+
+```bash
+ai completions zsh    # add eval "$(ai completions zsh)" to ~/.zshrc
+ai completions bash   # add eval "$(ai completions bash)" to ~/.bashrc
+ai completions fish   # add ai completions fish | source to config.fish
+```
+
 ### Multi-Model Comparison
 
 Generate with multiple models by comma-separating `-m`:
@@ -112,8 +129,28 @@ When running in a terminal that supports the [Kitty graphics protocol](https://s
 | `AI_CLI_VIDEO_MODEL` | Default video model (overrides `bytedance/seedance-2.0`) |
 | `AI_CLI_OUTPUT_DIR` | Default output directory for generated files |
 | `AI_CLI_PREVIEW` | Set to `1` to force inline image preview, `0` to disable |
+| `NO_COLOR` | Disable ANSI color output |
+| `FORCE_COLOR` | Force color output even when not a TTY |
 
 The `-m` flag always takes priority over `AI_CLI_*_MODEL` env vars. The `-o` flag always takes priority over `AI_CLI_OUTPUT_DIR`.
+
+### Timeouts
+
+Requests that exceed the timeout are aborted automatically:
+
+| Command | Timeout |
+|---|---|
+| `text` | 120 seconds |
+| `image` | 120 seconds |
+| `video` | 300 seconds |
+
+### Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | All generations failed |
+| `2` | Partial failure (some succeeded, some failed) |
 
 ## License
 

--- a/skills/ai-cli/SKILL.md
+++ b/skills/ai-cli/SKILL.md
@@ -1,0 +1,99 @@
+# ai-cli
+
+Generate text, images, and video from the terminal using AI models.
+
+## When to Use
+
+Use when you need to:
+- Generate images from text prompts or existing images
+- Generate video from text prompts or images
+- Generate text (summaries, explanations, code reviews) from prompts or piped content
+- Compare outputs across multiple models side-by-side
+- Build composable media pipelines by chaining commands via stdin/stdout
+
+## Prerequisites
+
+Requires `AI_GATEWAY_API_KEY` or a provider-specific key (e.g. `OPENAI_API_KEY`) in the environment.
+
+## Commands
+
+```bash
+ai text "explain this code"              # generate text
+ai image "a sunset over mountains"       # generate an image
+ai video "a spinning triangle"           # generate a video
+ai models --type image                   # list available models
+```
+
+## Key Flags
+
+```
+-m, --model <id>       Model ID (provider/name or short name), comma-separated for multi-model
+-o, --output <path>    Output file or directory
+-n, --count <n>        Number of generations per model
+-q, --quiet            Suppress progress output
+--json                 Output structured metadata as JSON (paths, timing, success/failure)
+```
+
+## Piping Patterns
+
+Chain commands for agent workflows:
+
+```bash
+# Pipe content in for summarization
+cat file.txt | ai text "summarize this"
+git diff | ai text "write a commit message"
+
+# Image-to-video pipeline
+ai image "a dragon" | ai video "animate this"
+
+# Image editing via stdin
+cat photo.png | ai image "make it a watercolor"
+```
+
+## Structured Output
+
+Use `--json` to get machine-readable results:
+
+```bash
+ai image "a sunset" --json
+```
+
+Returns:
+```json
+{
+  "elapsed_ms": 3420,
+  "count": 1,
+  "results": [
+    {
+      "index": 1,
+      "model": "openai/gpt-image-2",
+      "elapsed_ms": 3420,
+      "success": true,
+      "file": "/path/to/output.png"
+    }
+  ]
+}
+```
+
+## Multi-Model Comparison
+
+```bash
+ai image "a sunset" -m "openai/gpt-image-1,bfl/flux-2-pro,xai/grok-imagine-image"
+```
+
+## Output Behavior
+
+- **Interactive (TTY)**: saves to file, prints path to stderr
+- **Piped (non-TTY)**: writes raw content to stdout for chaining
+- **`-o <dir>`**: saves inside directory with auto-generated names
+
+## Timeouts
+
+- text/image: 120 seconds
+- video: 300 seconds
+
+## Exit Codes
+
+- `0` — success
+- `1` — all generations failed
+- `2` — partial failure (some succeeded)


### PR DESCRIPTION
## Summary

- **README**: Added `completions` command, `NO_COLOR`/`FORCE_COLOR` env vars, short model name resolution, exit codes, and timeouts
- **Web docs**: Added timeout section to commands reference, documented stdin joining delimiter in piping page, added missing providers (Alibaba, Recraft, Prodia) to models page, created troubleshooting page
- **SKILL.md**: Created `skills/ai-cli/SKILL.md` for agent discoverability with commands, flags, piping patterns, and structured output details