### PR TITLE
feat: stream ai text output as tokens arrive

### DIFF
--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -67,6 +67,8 @@ ai image -m flux-2-pro "a sunset"   # resolves to bfl/flux-2-pro
 
 ### text
 
+In interactive terminals, single-model text output streams to stdout as tokens arrive. Use `--json`, `-o`, or `AI_CLI_OUTPUT_DIR` when you need buffered output.
+
 ```
 -f, --format <fmt>       Output format: md, txt (default: md)
 -s, --system <prompt>    System prompt
@@ -114,23 +116,23 @@ When running in a terminal that supports the [Kitty graphics protocol](https://s
 
 ### Output Behavior
 
-- **text**: saves to `output.md` (interactive), stdout when piped
+- **text**: streams to stdout in interactive terminals for single-model runs, stdout when piped
 - **image/video**: saves to file (interactive), raw binary stdout when piped
 - **`-o <dir>`**: saves inside the directory with auto-generated names
 
 ### Environment Variables
 
-| Variable | Description |
-|---|---|
-| `AI_GATEWAY_API_KEY` | AI Gateway authentication key |
-| `OPENAI_API_KEY` | Provider-specific key (or other provider keys) |
-| `AI_CLI_TEXT_MODEL` | Default text model (overrides `openai/gpt-5.5`) |
-| `AI_CLI_IMAGE_MODEL` | Default image model (overrides `openai/gpt-image-2`) |
+| Variable             | Description                                              |
+| -------------------- | -------------------------------------------------------- |
+| `AI_GATEWAY_API_KEY` | AI Gateway authentication key                            |
+| `OPENAI_API_KEY`     | Provider-specific key (or other provider keys)           |
+| `AI_CLI_TEXT_MODEL`  | Default text model (overrides `openai/gpt-5.5`)          |
+| `AI_CLI_IMAGE_MODEL` | Default image model (overrides `openai/gpt-image-2`)     |
 | `AI_CLI_VIDEO_MODEL` | Default video model (overrides `bytedance/seedance-2.0`) |
-| `AI_CLI_OUTPUT_DIR` | Default output directory for generated files |
-| `AI_CLI_PREVIEW` | Set to `1` to force inline image preview, `0` to disable |
-| `NO_COLOR` | Disable ANSI color output |
-| `FORCE_COLOR` | Force color output even when not a TTY |
+| `AI_CLI_OUTPUT_DIR`  | Default output directory for generated files             |
+| `AI_CLI_PREVIEW`     | Set to `1` to force inline image preview, `0` to disable |
+| `NO_COLOR`           | Disable ANSI color output                                |
+| `FORCE_COLOR`        | Force color output even when not a TTY                   |
 
 The `-m` flag always takes priority over `AI_CLI_*_MODEL` env vars. The `-o` flag always takes priority over `AI_CLI_OUTPUT_DIR`.
 
@@ -138,19 +140,19 @@ The `-m` flag always takes priority over `AI_CLI_*_MODEL` env vars. The `-o` fla
 
 Requests that exceed the timeout are aborted automatically:
 
-| Command | Timeout |
-|---|---|
-| `text` | 120 seconds |
+| Command | Timeout     |
+| ------- | ----------- |
+| `text`  | 120 seconds |
 | `image` | 120 seconds |
 | `video` | 300 seconds |
 
 ### Exit Codes
 
-| Code | Meaning |
-|---|---|
-| `0` | Success |
-| `1` | All generations failed |
-| `2` | Partial failure (some succeeded, some failed) |
+| Code | Meaning                                       |
+| ---- | --------------------------------------------- |
+| `0`  | Success                                       |
+| `1`  | All generations failed                        |
+| `2`  | Partial failure (some succeeded, some failed) |
 
 ## License
 

--- a/packages/ai-cli/src/commands/text.test.ts
+++ b/packages/ai-cli/src/commands/text.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { Command } from "commander";
+
+const generateTextMock = mock(async () => ({ text: "buffered text" }));
+const streamTextMock = mock(() => ({
+  textStream: (async function* () {
+    yield "Hello, ";
+    yield "world";
+    yield "!";
+  })(),
+}));
+const gatewayMock = Object.assign(
+  mock((modelId: string) => modelId),
+  {
+    getAvailableModels: mock(async () => ({ models: [] })),
+  }
+);
+
+mock.module("ai", () => ({
+  generateText: generateTextMock,
+  gateway: gatewayMock,
+  streamText: streamTextMock,
+}));
+
+const { registerTextCommand } = await import("./text.js");
+
+function captureWrites(stream: typeof process.stdout | typeof process.stderr) {
+  const originalWrite = stream.write;
+  let output = "";
+  stream.write = ((chunk: unknown) => {
+    output += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+    return true;
+  }) as typeof stream.write;
+
+  return {
+    output: () => output,
+    restore: () => {
+      stream.write = originalWrite;
+    },
+  };
+}
+
+async function runTextCommand(args: string[]) {
+  const program = new Command();
+  program.exitOverride();
+  registerTextCommand(program);
+  await program.parseAsync(["node", "ai", ...args], { from: "node" });
+}
+
+describe("text command", () => {
+  const originalStdoutIsTTY = process.stdout.isTTY;
+  const originalStdinIsTTY = process.stdin.isTTY;
+  const originalOutputDir = process.env.AI_CLI_OUTPUT_DIR;
+
+  beforeEach(() => {
+    generateTextMock.mockClear();
+    streamTextMock.mockClear();
+    gatewayMock.mockClear();
+    delete process.env.AI_CLI_OUTPUT_DIR;
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: originalStdoutIsTTY,
+    });
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: originalStdinIsTTY,
+    });
+    if (originalOutputDir === undefined) {
+      delete process.env.AI_CLI_OUTPUT_DIR;
+    } else {
+      process.env.AI_CLI_OUTPUT_DIR = originalOutputDir;
+    }
+  });
+
+  test("streams single-model interactive text to stdout", async () => {
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await runTextCommand(["text", "-m", "openai/gpt-4.1-mini", "say hello"]);
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1);
+    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(stdout.output()).toBe("Hello, world!");
+    expect(stderr.output()).toContain(
+      "Generated text with openai/gpt-4.1-mini"
+    );
+  });
+
+  test("keeps json output on the buffered path", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ai-cli-text-"));
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await runTextCommand([
+        "text",
+        "-m",
+        "openai/gpt-4.1-mini",
+        "--json",
+        "--output",
+        join(dir, "out.md"),
+        "say hello",
+      ]);
+    } finally {
+      stdout.restore();
+      stderr.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    expect(streamTextMock).not.toHaveBeenCalled();
+    expect(stdout.output()).toContain('"success": true');
+    expect(stderr.output()).not.toContain("Hello, world!");
+  });
+});

--- a/packages/ai-cli/src/commands/text.test.ts
+++ b/packages/ai-cli/src/commands/text.test.ts
@@ -6,13 +6,27 @@ import { join } from "path";
 import { Command } from "commander";
 
 const generateTextMock = mock(async () => ({ text: "buffered text" }));
-const streamTextMock = mock(() => ({
-  textStream: (async function* () {
-    yield "Hello, ";
-    yield "world";
-    yield "!";
-  })(),
-}));
+
+interface StreamTextMockResult {
+  textStream: AsyncIterable<string>;
+  finishReason: Promise<string>;
+}
+
+function streamTextResult(
+  chunks: string[],
+  finishReason = Promise.resolve("stop")
+): StreamTextMockResult {
+  return {
+    textStream: (async function* () {
+      yield* chunks;
+    })(),
+    finishReason,
+  };
+}
+
+const streamTextMock = mock(() =>
+  streamTextResult(["Hello, ", "world", "!"])
+);
 const gatewayMock = Object.assign(
   mock((modelId: string) => modelId),
   {
@@ -102,6 +116,35 @@ describe("text command", () => {
     expect(generateTextMock).not.toHaveBeenCalled();
     expect(stdout.output()).toBe("Hello, world!");
     expect(stderr.output()).toContain(
+      "Generated text with openai/gpt-4.1-mini"
+    );
+  });
+
+  test("surfaces streaming errors before reporting success", async () => {
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const error = new Error("rate limited");
+    streamTextMock.mockImplementationOnce(() =>
+      streamTextResult(["partial"], Promise.reject(error))
+    );
+    const stdout = captureWrites(process.stdout);
+    const stderr = captureWrites(process.stderr);
+
+    try {
+      await expect(
+        runTextCommand(["text", "-m", "openai/gpt-4.1-mini", "say hello"])
+      ).rejects.toThrow("rate limited");
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1);
+    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(stdout.output()).toBe("partial");
+    expect(stderr.output()).not.toContain(
       "Generated text with openai/gpt-4.1-mini"
     );
   });

--- a/packages/ai-cli/src/commands/text.ts
+++ b/packages/ai-cli/src/commands/text.ts
@@ -111,6 +111,7 @@ export function registerTextCommand(program: Command) {
           process.stdout.write(part);
           endsWithNewline = part.endsWith("\n");
         }
+        await result.finishReason;
 
         if (opts.quiet) {
           if (!endsWithNewline) process.stdout.write("\n");

--- a/packages/ai-cli/src/commands/text.ts
+++ b/packages/ai-cli/src/commands/text.ts
@@ -1,10 +1,11 @@
-import { generateText, gateway } from "ai";
+import { generateText, gateway, streamText } from "ai";
 import type { Command } from "commander";
 
 import { buildJobs, runJobs } from "../lib/jobs.js";
 import { resolveModels } from "../lib/models.js";
 import type { OutputFormat } from "../lib/output.js";
 import { parsePositiveInt, parseTemperature } from "../lib/parse.js";
+import { formatElapsed } from "../lib/progress.js";
 import { readStdin, stdinAsText } from "../lib/stdin.js";
 
 const DEFAULT_CONCURRENCY = 4;
@@ -79,6 +80,48 @@ export function registerTextCommand(program: Command) {
       const temperature = opts.temperature
         ? parseTemperature(opts.temperature)
         : undefined;
+
+      const isSimpleStdoutPath =
+        models.length === 1 &&
+        countPerModel === 1 &&
+        !opts.output &&
+        !process.env.AI_CLI_OUTPUT_DIR &&
+        !opts.json &&
+        process.stdout.isTTY;
+
+      if (isSimpleStdoutPath) {
+        const modelId = models[0];
+        const start = Date.now();
+        const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+        const result = streamText({
+          headers: {
+            "http-referer": "https://github.com/vercel-labs/ai-cli",
+            "x-title": "ai-cli",
+          },
+          model: gateway(modelId),
+          prompt: fullPrompt,
+          system: opts.system,
+          maxOutputTokens: maxTokens,
+          temperature,
+          abortSignal: abort,
+        });
+
+        let endsWithNewline = false;
+        for await (const part of result.textStream) {
+          process.stdout.write(part);
+          endsWithNewline = part.endsWith("\n");
+        }
+
+        if (opts.quiet) {
+          if (!endsWithNewline) process.stdout.write("\n");
+        } else {
+          const elapsed = formatElapsed(Date.now() - start);
+          process.stderr.write(
+            `\nGenerated text with ${modelId} (${elapsed})\n`
+          );
+        }
+        return;
+      }
 
       const jobs = buildJobs(models, countPerModel);
 

--- a/skills/ai-cli/SKILL.md
+++ b/skills/ai-cli/SKILL.md
@@ -5,6 +5,7 @@ Generate text, images, and video from the terminal using AI models.
 ## When to Use
 
 Use when you need to:
+
 - Generate images from text prompts or existing images
 - Generate video from text prompts or images
 - Generate text (summaries, explanations, code reviews) from prompts or piped content
@@ -23,6 +24,8 @@ ai image "a sunset over mountains"       # generate an image
 ai video "a spinning triangle"           # generate a video
 ai models --type image                   # list available models
 ```
+
+Single-model `ai text` runs stream tokens to stdout in interactive terminals. Use `--json`, `-o`, or `AI_CLI_OUTPUT_DIR` for buffered output.
 
 ## Key Flags
 
@@ -59,6 +62,7 @@ ai image "a sunset" --json
 ```
 
 Returns:
+
 ```json
 {
   "elapsed_ms": 3420,
@@ -83,7 +87,7 @@ ai image "a sunset" -m "openai/gpt-image-1,bfl/flux-2-pro,xai/grok-imagine-image
 
 ## Output Behavior
 
-- **Interactive (TTY)**: saves to file, prints path to stderr
+- **Interactive (TTY)**: text streams to stdout for single-model runs; image/video saves to file and prints path to stderr
 - **Piped (non-TTY)**: writes raw content to stdout for chaining
 - **`-o <dir>`**: saves inside directory with auto-generated names
 


### PR DESCRIPTION
## Summary

`ai text` currently waits for the full response from `generateText` before printing. On a one-sentence prompt that's a 1s blank terminal so not a big deal, but on a long-form generation it's much worse. 

AI SDK 6 already ships `streamText`. This PR uses it for the simple single-model interactive case so tokens appear in the terminal as they arrive.

## Why this matters

The "agent-native CLI" tagline implies responsive feedback in interactive terminals. Buffered text feels broken on long prompts even when it's fast. Every comparable tool streams: MMX-CLI has `--stream`, aichat is built around streaming, Charm's mods streams by default. Streaming is also strictly cheaper for the user, since they can ctrl-C as soon as a response is going off track instead of paying for the full generation.

## Demo

Live timing breakdown from a 5-sentence prompt against `openai/gpt-4.1-mini` (captured via PTY so stdout is treated as a TTY). Thought it'd be helpful to see the breakdown and not just the gif.

```
t= 1.07s  +  2b  'In'
t= 1.13s  +  4b  ''s'
t= 1.39s  + 10b  ' recursive'
t= 1.45s  +  4b  ' own'
t= 1.51s  +  4b  ' its'
t= 1.56s  +  6b  ' frame'
t= 1.72s  +  8b  ' silence'
...
t= 2.77s  + 48b  '\r\nGenerated text with openai/gpt-4.1-mini (2s)\r\n'

Total chunks:  154
Total bytes:   830
First byte at: 1.07s
Last byte at:  2.77s
Span:          1.70s
```

154 small chunks over 1.7 seconds, instead of one ~2-second blank-then-dump.

<img width="1100" height="400" alt="ai-text-streaming" src="https://github.com/user-attachments/assets/6dd33c51-9398-4e5d-9e1b-02c1f4273ae7" />

## Testing

```
bun run typecheck   # passes
bun test            # 73 tests, 0 fail (3 new in text.test.ts)
bun run check       # 17 pre-existing format issues outside this change (was 19 on upstream/main)
```

Manual: streaming verified live against `openai/gpt-4.1-mini` and `anthropic/claude-3.5-haiku` via AI Gateway. `--json`, multi-model, and piped paths confirmed unchanged via PTY-instrumented runs.

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
