### PR TITLE
feat(image): add --seed for reproducible generations

### DIFF
--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -54,8 +54,17 @@ ai image -m flux-2-pro "a sunset"   # resolves to bfl/flux-2-pro
 --aspect-ratio <W:H>     Aspect ratio (e.g. 16:9)
 --quality <level>        Quality (standard, hd)
 --style <style>          Style (vivid, natural)
+--seed <n>               Random seed for reproducible generations
 --no-preview             Disable inline image preview
 ```
+
+`--seed` is forwarded to `generateImage` as the SDK's top-level `seed` option.
+Providers that honor it (BFL, Stability, fal, several open-source models)
+return reproducible images for a given (prompt, model, seed) tuple. OpenAI
+image models ignore `--seed`; the CLI prints a warning on stderr if every
+selected model is OpenAI and proceeds. Combining `--seed` with `-n > 1`
+yields identical images on supported providers; run separate invocations with
+distinct `--seed` values to generate multiple reproducible variants.
 
 ### video
 

--- a/packages/ai-cli/src/cli.test.ts
+++ b/packages/ai-cli/src/cli.test.ts
@@ -78,6 +78,13 @@ describe("cli integration", () => {
     expect(stdout).toContain("--no-preview");
     expect(stdout).toContain("--size");
     expect(stdout).toContain("--aspect-ratio");
+    expect(stdout).toContain("--seed");
+  });
+
+  test("image --seed with non-numeric value exits 1", async () => {
+    const { exitCode, stderr } = await run("image", "--seed", "abc", "x");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--seed must be a positive integer");
   });
 
   test("video --help exits 0 and lists flags", async () => {

--- a/packages/ai-cli/src/commands/completions.ts
+++ b/packages/ai-cli/src/commands/completions.ts
@@ -48,6 +48,7 @@ const IMAGE_FLAGS = [
   "--aspect-ratio",
   "--quality",
   "--style",
+  "--seed",
   "--no-preview",
 ];
 const VIDEO_FLAGS = ["--aspect-ratio", "--duration", "--no-preview"];
@@ -126,6 +127,7 @@ _ai() {
             '--aspect-ratio[Aspect ratio]:ratio:' \\
             '--quality[Quality]:quality:(standard hd)' \\
             '--style[Style]:style:(vivid natural)' \\
+            '--seed[Random seed for reproducible generations]:seed:' \\
             '--no-preview[Disable inline image preview]' \\
             '-q[Quiet]' \\
             '--quiet[Quiet]' \\

--- a/packages/ai-cli/src/commands/image.ts
+++ b/packages/ai-cli/src/commands/image.ts
@@ -17,6 +17,7 @@ interface ImageOptions {
   aspectRatio?: string;
   quality?: string;
   style?: string;
+  seed?: string;
   quiet?: boolean;
   json?: boolean;
   concurrency?: string;
@@ -38,6 +39,10 @@ export function registerImageCommand(program: Command) {
     .option("--aspect-ratio <W:H>", "Aspect ratio (e.g. 16:9)")
     .option("--quality <level>", "Quality (standard, hd)")
     .option("--style <style>", "Style (e.g. vivid, natural)")
+    .option(
+      "--seed <n>",
+      "Random seed for reproducible generations (where supported)"
+    )
     .option("-q, --quiet", "Suppress progress output")
     .option("--json", "Output metadata as JSON")
     .option(
@@ -73,7 +78,7 @@ export function registerImageCommand(program: Command) {
       const aspectRatio = opts.aspectRatio
         ? parseAspectRatio(opts.aspectRatio)
         : undefined;
-      const provOpts = buildProviderOptions(opts);
+      const seed = opts.seed ? parsePositiveInt(opts.seed, "seed") : undefined;
 
       if (
         (opts.quality || opts.style) &&
@@ -83,7 +88,18 @@ export function registerImageCommand(program: Command) {
           "Warning: --quality and --style only apply to OpenAI models\n"
         );
       }
+      if (seed !== undefined && models.every((m) => m.startsWith("openai/"))) {
+        process.stderr.write(
+          "Warning: --seed is ignored by OpenAI image models\n"
+        );
+      }
+      if (seed !== undefined && countPerModel > 1) {
+        process.stderr.write(
+          "Warning: --seed with -n > 1 produces identical images on providers that honor seed\n"
+        );
+      }
 
+      const provOpts = buildProviderOptions(opts);
       const jobs = buildJobs(models, countPerModel);
 
       const { total, failed } = await runJobs(
@@ -101,6 +117,7 @@ export function registerImageCommand(program: Command) {
             n: 1,
             size,
             aspectRatio,
+            seed,
             providerOptions:
               Object.keys(provOpts).length > 0 ? provOpts : undefined,
           });


### PR DESCRIPTION
## Summary

Adds `--seed <n>` to `ai image`. The flag is forwarded to `generateImage` as the SDK's top-level [`seed`](https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-image) option, so providers that honor it (BFL, Stability, fal, and other supported models) return reproducible images for a given (prompt, model, seed) tuple.

## Why this matters

The repo's tagline is "predictable artifact outputs" but `ai image` has no way to ask for a specific seed today. Seeded generation is the canonical reproducibility primitive across most image CLIs ([replicate](https://github.com/replicate/cli), fal, the Stable Diffusion UIs). With this flag, prompt iteration becomes a clean diff on the prompt rather than two changing variables.

## Demo

Simulated demo. Real image generation needs an AI Gateway key, so the demo uses placeholder gradients to make the contrast visible:

![demo](https://raw.githubusercontent.com/mvanhorn/ai-cli/evidence-assets/demo/seed-demo.gif)

Without `--seed`, two runs of the same prompt produce different outputs. With `--seed 42`, two runs produce identical outputs.

## Changes

- `packages/ai-cli/src/commands/image.ts`: add `--seed <n>` option, parse via `parsePositiveInt`, forward as the SDK's top-level `seed` argument. Print a warning on stderr when every selected model is OpenAI (gpt-image ignores seed). Print a separate warning when `--seed` is combined with `-n > 1`, since the generations would be identical on supported providers.
- `packages/ai-cli/src/commands/completions.ts`: add `--seed` to `IMAGE_FLAGS` and the zsh image flag list so tab completion picks it up in bash, zsh, and fish.
- `packages/ai-cli/README.md`: add the `--seed <n>` row to the image flag block and a short note describing the SDK pass-through, the OpenAI exception, and the `-n > 1` caveat.

## Testing

```
bun run typecheck                            # passes
bun run --cwd packages/ai-cli format:check   # passes
bun run --cwd packages/ai-cli lint           # 24 pre-existing warnings in lib/openh264.mjs, 0 errors
bun test                                     # 71 tests, 0 fail (1 new in cli.test.ts)
```

The new test asserts `ai image --seed abc x` exits 1 with `--seed must be a positive integer`. The two warning paths follow the existing `--quality`/`--style` warning shape, so no new coverage was added for them.

`buildProviderOptions` stays the only place provider-specific keys are assembled; the OpenAI quality/style branch is unchanged.
