### PR TITLE
feat: add --timeout flag to image, text, and video commands

### DIFF
--- a/apps/web/docs/commands.mdx
+++ b/apps/web/docs/commands.mdx
@@ -174,13 +174,21 @@ Models are fetched live from the AI Gateway.
 
 Requests that exceed the per-command timeout are aborted automatically:
 
-| Command | Timeout |
+| Command | Default timeout |
 | --- | --- |
 | `text` | 120 seconds |
 | `image` | 120 seconds |
 | `video` | 300 seconds |
 
 Video generation uses a longer timeout because models typically need more processing time.
+
+Override the default with `--timeout <seconds>`. Useful for complex prompts where the default is too tight:
+
+```bash
+ai image "complex sprite atlas with 72 cells..." --timeout 600
+ai text "long structured response..." --timeout 300
+ai video "extended scene..." --timeout 900
+```
 
 ## Exit codes
 

--- a/apps/web/docs/troubleshooting.mdx
+++ b/apps/web/docs/troubleshooting.mdx
@@ -23,13 +23,19 @@ Add the export to your shell profile (`~/.zshrc`, `~/.bashrc`) to persist across
 
 Requests are aborted if they exceed the per-command timeout:
 
-| Command | Timeout |
+| Command | Default timeout |
 | --- | --- |
 | `text` | 120 seconds |
 | `image` | 120 seconds |
 | `video` | 300 seconds |
 
-If you're consistently hitting timeouts, try a faster model variant (e.g. `bytedance/seedance-2.0-fast` instead of `bytedance/seedance-2.0`).
+Two ways to handle them:
+
+1. Bump the timeout per command with `--timeout <seconds>`:
+   ```bash
+   ai image "complex sprite atlas..." --timeout 600
+   ```
+2. Try a faster model variant (e.g. `bytedance/seedance-2.0-fast` instead of `bytedance/seedance-2.0`).
 
 ## `--quality` / `--style` warning
 

--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -128,11 +128,18 @@ The `-m` flag always takes priority over `AI_CLI_*_MODEL` env vars. The `-o` fla
 
 Requests that exceed the timeout are aborted automatically:
 
-| Command | Timeout |
+| Command | Default timeout |
 |---|---|
 | `text` | 120 seconds |
 | `image` | 120 seconds |
 | `video` | 300 seconds |
+
+Override with `--timeout <seconds>` per command. Useful for complex prompts (large images, long sprite atlases) where the default is too tight:
+
+```bash
+ai image "complex sprite atlas..." --timeout 600
+ai video "longer scene..." --timeout 900
+```
 
 ### Exit Codes
 

--- a/packages/ai-cli/src/commands/image.ts
+++ b/packages/ai-cli/src/commands/image.ts
@@ -21,6 +21,7 @@ interface ImageOptions {
   json?: boolean;
   concurrency?: string;
   preview?: boolean;
+  timeout?: string;
 }
 
 export function registerImageCommand(program: Command) {
@@ -47,6 +48,10 @@ export function registerImageCommand(program: Command) {
     .option(
       "-p, --concurrency <n>",
       `Max parallel generations (default: ${DEFAULT_CONCURRENCY})`
+    )
+    .option(
+      "--timeout <seconds>",
+      `Per-request timeout in seconds (default: ${DEFAULT_TIMEOUT_MS / 1000})`
     )
     .action(async (rawPrompt: string | undefined, opts: ImageOptions) => {
       const prompt = rawPrompt?.trim() || undefined;
@@ -88,10 +93,14 @@ export function registerImageCommand(program: Command) {
 
       const jobs = buildJobs(models, countPerModel);
 
+      const timeoutMs = opts.timeout
+        ? parsePositiveInt(opts.timeout, "timeout") * 1000
+        : DEFAULT_TIMEOUT_MS;
+
       const { total, failed } = await runJobs(
         jobs,
         async (modelId) => {
-          const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+          const abort = AbortSignal.timeout(timeoutMs);
 
           if (gatewayModels.languageImageModelIds.has(modelId)) {
             const messageContent: Array<

--- a/packages/ai-cli/src/commands/text.ts
+++ b/packages/ai-cli/src/commands/text.ts
@@ -21,6 +21,7 @@ interface TextOptions {
   concurrency?: string;
   quiet?: boolean;
   json?: boolean;
+  timeout?: string;
 }
 
 function resolveFormat(fmt?: string): OutputFormat {
@@ -50,6 +51,10 @@ export function registerTextCommand(program: Command) {
     .option("-t, --temperature <n>", "Temperature (0-2)")
     .option("-q, --quiet", "Suppress progress output")
     .option("--json", "Output metadata as JSON")
+    .option(
+      "--timeout <seconds>",
+      `Per-request timeout in seconds (default: ${DEFAULT_TIMEOUT_MS / 1000})`
+    )
     .action(async (rawPrompt: string | undefined, opts: TextOptions) => {
       const prompt = rawPrompt?.trim() || undefined;
       const stdin = await readStdin();
@@ -83,10 +88,14 @@ export function registerTextCommand(program: Command) {
 
       const jobs = buildJobs(models, countPerModel);
 
+      const timeoutMs = opts.timeout
+        ? parsePositiveInt(opts.timeout, "timeout") * 1000
+        : DEFAULT_TIMEOUT_MS;
+
       const { total, failed } = await runJobs(
         jobs,
         async (modelId) => {
-          const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+          const abort = AbortSignal.timeout(timeoutMs);
           const result = await generateText({
             headers: {
               "http-referer": "https://github.com/vercel-labs/ai-cli",

--- a/packages/ai-cli/src/commands/video.ts
+++ b/packages/ai-cli/src/commands/video.ts
@@ -23,6 +23,7 @@ interface VideoOptions {
   json?: boolean;
   concurrency?: string;
   preview?: boolean;
+  timeout?: string;
 }
 
 export function registerVideoCommand(program: Command) {
@@ -47,6 +48,10 @@ export function registerVideoCommand(program: Command) {
     .option(
       "-p, --concurrency <n>",
       `Max parallel generations (default: ${DEFAULT_CONCURRENCY})`
+    )
+    .option(
+      "--timeout <seconds>",
+      `Per-request timeout in seconds (default: ${DEFAULT_TIMEOUT_MS / 1000})`
     )
     .action(async (rawPrompt: string | undefined, opts: VideoOptions) => {
       const prompt = rawPrompt?.trim() || undefined;
@@ -79,10 +84,14 @@ export function registerVideoCommand(program: Command) {
 
       const jobs = buildJobs(models, countPerModel);
 
+      const timeoutMs = opts.timeout
+        ? parsePositiveInt(opts.timeout, "timeout") * 1000
+        : DEFAULT_TIMEOUT_MS;
+
       const { total, failed } = await runJobs(
         jobs,
         async (modelId) => {
-          const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+          const abort = AbortSignal.timeout(timeoutMs);
           const result = await generateVideo({
             headers: {
               "http-referer": "https://github.com/vercel-labs/ai-cli",


### PR DESCRIPTION
## Summary

Adds a `--timeout <seconds>` flag to `image`, `text`, and `video`. Defaults are unchanged (120s for image/text, 300s for video), so this is purely additive.

## Why

The hardcoded 120s default in `image` (and `text`) aborts complex prompts before the AI Gateway has a chance to respond. Real example: a sprite atlas prompt (1536x1872, 72 cells, strict layout constraints) consistently hits the 120s wall and surfaces as `Gateway request failed: The operation timed out` regardless of model. There is no escape hatch in the current CLI: the user has to fork or downgrade the prompt.

The Gateway itself is not the bottleneck. Per [AI Gateway docs](https://vercel.com/docs/ai-gateway/models-and-providers/provider-timeouts#timeout-limits), provider timeouts go from 1s up to **789,000ms (~13 min)**, and that timeout only measures time-to-first-byte. The CLI's `AbortSignal.timeout(120_000)` is what fires first.

The current docs even acknowledge this in `troubleshooting.mdx` ("If you're consistently hitting timeouts, try a faster model variant"), but switching models is not always the right answer — for image generation, model choice is dictated by quality requirements, not latency tolerance.

## What changes

- `--timeout <seconds>` on `image`, `text`, `video`. Reused `parsePositiveInt` for validation.
- README, `commands.mdx`, `troubleshooting.mdx` updated to document the flag and renamed the existing column to "Default timeout" for clarity.
- No default changed, no behavior change for existing invocations.

## Verification

- `bun run typecheck` passes
- `bun run format:check` passes
- `bun run lint` passes (24 preexisting warnings, 0 new)
- `bun run build` produces a working binary
- `dist/ai image --help` shows the new flag with the correct default

## Example

```bash
ai image "complex sprite atlas with 72 cells..." --timeout 600
ai text "long structured response..." --timeout 300
ai video "extended scene..." --timeout 900
```