### PR TITLE
feat: add multi-provider support (OpenRouter, fal.ai, OpenAI direct)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,14 @@
     },
     "packages/ai-cli": {
       "name": "ai-cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "ai": "./src/index.ts",
       },
       "dependencies": {
+        "@ai-sdk/fal": "^2.0.33",
+        "@ai-sdk/openai": "^3.0.58",
+        "@openrouter/ai-sdk-provider": "^2.9.0",
         "ai": "^6.0.173",
         "commander": "^14.0.3",
       },
@@ -61,7 +64,11 @@
 
     "@ai-cli/web": ["@ai-cli/web@workspace:apps/web"],
 
+    "@ai-sdk/fal": ["@ai-sdk/fal@2.0.33", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Qb7mxM110c4nVVRORoqRpdQn05K1XsNeJ1s+i1aIYDM/mOgKAsNi/v3zZmi798t05C0hedPtcJg2+iHhobaN/w=="],
+
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.108", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hOtwiM6E/m1PgqHnx0/grvh0P/kjENHsN222OL5iYPQwfWmcX+26oFXM7HGL/UzonB+RORMkYAbskgAiANVwCQ=="],
+
+    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.58", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2+5xGMROmrBboJuoOwqLL3b/o3i56+NRdxXDNVAiTyYjLiBj6KzembeuyuBT217be1X+zkEfAqD1H0irJlGIyw=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
 
@@ -182,6 +189,8 @@
     "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA=="],
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg=="],
+
+    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.9.0", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Seva+NCa0WUQnJIUE5GzHsUv1WTIeyqwz0ELl2VtS6NP+eF+77yCXGFVOMbvoCM7QMjlnhv7931e89R+8pJdcQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 

--- a/packages/ai-cli/package.json
+++ b/packages/ai-cli/package.json
@@ -36,6 +36,9 @@
     "prepublishOnly": "bun run typecheck"
   },
   "dependencies": {
+    "@ai-sdk/fal": "^2.0.33",
+    "@ai-sdk/openai": "^3.0.58",
+    "@openrouter/ai-sdk-provider": "^2.9.0",
     "ai": "^6.0.173",
     "commander": "^14.0.3"
   },

--- a/packages/ai-cli/src/commands/image.ts
+++ b/packages/ai-cli/src/commands/image.ts
@@ -1,6 +1,7 @@
-import { generateImage, generateText, gateway } from "ai";
+import { generateImage, generateText } from "ai";
 import type { Command } from "commander";
 
+import { createProvider } from "../lib/provider.js";
 import { buildJobs, runJobs } from "../lib/jobs.js";
 import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import { parsePositiveInt, parseSize, parseAspectRatio } from "../lib/parse.js";
@@ -66,8 +67,9 @@ export function registerImageCommand(program: Command) {
         imagePrompt = prompt!;
       }
 
-      const gatewayModels = await fetchGatewayModels();
-      const models = resolveModels("image", opts.model, gatewayModels.image);
+      const provider = createProvider();
+      const gatewayModels = await fetchGatewayModels(provider.backend);
+      const models = resolveModels("image", opts.model, gatewayModels.image, provider.backend);
       const countPerModel = opts.count
         ? parsePositiveInt(opts.count, "count")
         : 1;
@@ -93,7 +95,8 @@ export function registerImageCommand(program: Command) {
         async (modelId) => {
           const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
 
-          if (gatewayModels.languageImageModelIds.has(modelId)) {
+          // Language-image models (e.g. GPT-4o with image output) — Vercel gateway only
+          if (provider.backend === "vercel" && gatewayModels.languageImageModelIds.has(modelId)) {
             const messageContent: Array<
               | { type: "text"; text: string }
               | { type: "image"; image: Uint8Array }
@@ -104,27 +107,18 @@ export function registerImageCommand(program: Command) {
               for (const img of imagePrompt.images) {
                 messageContent.push({ type: "image", image: img });
               }
-              if (imagePrompt.text) {
-                messageContent.push({
-                  type: "text",
-                  text: imagePrompt.text,
-                });
-              } else {
-                messageContent.push({
-                  type: "text",
-                  text: "Generate an image",
-                });
-              }
+              messageContent.push({
+                type: "text",
+                text: imagePrompt.text ?? "Generate an image",
+              });
             }
-            const creator = gatewayModels.all.find(
-              (m) => m.id === modelId
-            )?.creator;
+            const creator = gatewayModels.all.find((m) => m.id === modelId)?.creator;
             const result = await generateText({
               headers: {
                 "http-referer": "https://github.com/vercel-labs/ai-cli",
                 "x-title": "ai-cli",
               },
-              model: gateway(modelId),
+              model: provider.text(modelId),
               messages: [{ role: "user", content: messageContent }],
               abortSignal: abort,
               providerOptions:
@@ -136,9 +130,7 @@ export function registerImageCommand(program: Command) {
               f.mediaType.startsWith("image/")
             );
             if (!imageFile) {
-              throw new Error(
-                `Model ${modelId} did not return an image in the response`
-              );
+              throw new Error(`Model ${modelId} did not return an image in the response`);
             }
             return Buffer.from(imageFile.uint8Array);
           }
@@ -148,7 +140,7 @@ export function registerImageCommand(program: Command) {
               "http-referer": "https://github.com/vercel-labs/ai-cli",
               "x-title": "ai-cli",
             },
-            model: gateway.image(modelId),
+            model: provider.image(modelId),
             prompt: imagePrompt,
             abortSignal: abort,
             n: 1,

--- a/packages/ai-cli/src/commands/models.ts
+++ b/packages/ai-cli/src/commands/models.ts
@@ -41,7 +41,9 @@ export function registerModelsCommand(program: Command) {
         }
         const filterCreator = opts.creator?.toLowerCase();
 
-        const gatewayModels = await fetchGatewayModels();
+        const { createProvider } = await import("../lib/provider.js");
+        const provider = createProvider();
+        const gatewayModels = await fetchGatewayModels(provider.backend);
 
         if (opts.json) {
           let entries = gatewayModels.all;

--- a/packages/ai-cli/src/commands/text.ts
+++ b/packages/ai-cli/src/commands/text.ts
@@ -1,6 +1,7 @@
-import { generateText, gateway } from "ai";
+import { generateText } from "ai";
 import type { Command } from "commander";
 
+import { createProvider } from "../lib/provider.js";
 import { buildJobs, runJobs } from "../lib/jobs.js";
 import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import type { OutputFormat } from "../lib/output.js";
@@ -68,9 +69,10 @@ export function registerTextCommand(program: Command) {
         fullPrompt = prompt!;
       }
 
+      const provider = createProvider();
       const format = resolveFormat(opts.format);
-      const gatewayModels = await fetchGatewayModels();
-      const models = resolveModels("text", opts.model, gatewayModels.text);
+      const gatewayModels = await fetchGatewayModels(provider.backend);
+      const models = resolveModels("text", opts.model, gatewayModels.text, provider.backend);
       const countPerModel = opts.count
         ? parsePositiveInt(opts.count, "count")
         : 1;
@@ -92,7 +94,7 @@ export function registerTextCommand(program: Command) {
               "http-referer": "https://github.com/vercel-labs/ai-cli",
               "x-title": "ai-cli",
             },
-            model: gateway(modelId),
+            model: provider.text(modelId),
             prompt: fullPrompt,
             system: opts.system,
             maxOutputTokens: maxTokens,

--- a/packages/ai-cli/src/commands/video.ts
+++ b/packages/ai-cli/src/commands/video.ts
@@ -1,6 +1,7 @@
-import { experimental_generateVideo as generateVideo, gateway } from "ai";
+import { experimental_generateVideo as generateVideo } from "ai";
 import type { Command } from "commander";
 
+import { createProvider } from "../lib/provider.js";
 import { buildJobs, runJobs } from "../lib/jobs.js";
 import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import {
@@ -65,8 +66,17 @@ export function registerVideoCommand(program: Command) {
           : { image: new Uint8Array(stdin) };
       }
 
-      const gatewayModels = await fetchGatewayModels();
-      const models = resolveModels("video", opts.model, gatewayModels.video);
+      const provider = createProvider();
+      if (!provider.video) {
+        process.stderr.write(
+          `Error: video generation is not supported with the "${provider.backend}" backend alone.\n` +
+          `Set FAL_KEY to enable video via fal.ai (Kling, Wan, HunyuanVideo, Runway Gen3),\n` +
+          `or use AI_GATEWAY_API_KEY for Vercel AI Gateway.\n`
+        );
+        process.exit(1);
+      }
+      const gatewayModels = await fetchGatewayModels(provider.backend);
+      const models = resolveModels("video", opts.model, gatewayModels.video, provider.backend);
       const countPerModel = opts.count
         ? parsePositiveInt(opts.count, "count")
         : 1;
@@ -88,7 +98,7 @@ export function registerVideoCommand(program: Command) {
               "http-referer": "https://github.com/vercel-labs/ai-cli",
               "x-title": "ai-cli",
             },
-            model: gateway.video(modelId),
+            model: provider.video!(modelId),
             prompt: videoPrompt,
             abortSignal: abort,
             aspectRatio,

--- a/packages/ai-cli/src/lib/models.test.ts
+++ b/packages/ai-cli/src/lib/models.test.ts
@@ -29,35 +29,35 @@ function mockGatewayError() {
 
 describe("resolveModels", () => {
   test("returns default when no user model", () => {
-    expect(resolveModels("text")[0]).toContain("/");
-    expect(resolveModels("image")[0]).toContain("/");
-    expect(resolveModels("video")[0]).toContain("/");
+    expect(resolveModels("text", undefined, undefined, "vercel")[0]).toContain("/");
+    expect(resolveModels("image", undefined, undefined, "vercel")[0]).toContain("/");
+    expect(resolveModels("video", undefined, undefined, "vercel")[0]).toContain("/");
   });
 
   test("returns fully-qualified model as-is", () => {
-    expect(resolveModels("text", "openai/gpt-4")).toEqual(["openai/gpt-4"]);
-    expect(resolveModels("image", "openai/gpt-image-1")).toEqual([
+    expect(resolveModels("text", "openai/gpt-4", undefined, "vercel")).toEqual(["openai/gpt-4"]);
+    expect(resolveModels("image", "openai/gpt-image-1", undefined, "vercel")).toEqual([
       "openai/gpt-image-1",
     ]);
   });
 
   test("expands short names when knownModels provided", () => {
     const known = [{ id: "openai/gpt-image-1" }, { id: "bfl/flux-2-pro" }];
-    expect(resolveModels("image", "gpt-image-1", known)).toEqual([
+    expect(resolveModels("image", "gpt-image-1", known, "vercel")).toEqual([
       "openai/gpt-image-1",
     ]);
-    expect(resolveModels("image", "flux-2-pro", known)).toEqual([
+    expect(resolveModels("image", "flux-2-pro", known, "vercel")).toEqual([
       "bfl/flux-2-pro",
     ]);
   });
 
   test("returns unknown short names as-is when no knownModels", () => {
-    expect(resolveModels("text", "my-model")).toEqual(["my-model"]);
+    expect(resolveModels("text", "my-model", undefined, "vercel")).toEqual(["my-model"]);
   });
 
   test("returns unknown short names as-is when not in knownModels", () => {
     const known = [{ id: "openai/gpt-5" }];
-    expect(resolveModels("text", "nonexistent", known)).toEqual([
+    expect(resolveModels("text", "nonexistent", known, "vercel")).toEqual([
       "nonexistent",
     ]);
   });
@@ -65,37 +65,39 @@ describe("resolveModels", () => {
 
 describe("resolveModels multi", () => {
   test("returns default when no user model", () => {
-    const result = resolveModels("text");
+    const result = resolveModels("text", undefined, undefined, "vercel");
     expect(result).toHaveLength(1);
     expect(result[0]).toContain("/");
   });
 
   test("splits comma-separated models", () => {
-    const result = resolveModels("image", "openai/gpt-image-1,bfl/flux-2-pro");
+    const result = resolveModels("image", "openai/gpt-image-1,bfl/flux-2-pro", undefined, "vercel");
     expect(result).toEqual(["openai/gpt-image-1", "bfl/flux-2-pro"]);
   });
 
   test("trims whitespace around model names", () => {
     const result = resolveModels(
       "image",
-      "openai/gpt-image-1 , bfl/flux-2-pro"
+      "openai/gpt-image-1 , bfl/flux-2-pro",
+      undefined,
+      "vercel"
     );
     expect(result).toEqual(["openai/gpt-image-1", "bfl/flux-2-pro"]);
   });
 
   test("expands short names in comma list", () => {
     const known = [{ id: "openai/gpt-image-1" }, { id: "bfl/flux-2-pro" }];
-    const result = resolveModels("image", "gpt-image-1,flux-2-pro", known);
+    const result = resolveModels("image", "gpt-image-1,flux-2-pro", known, "vercel");
     expect(result).toEqual(["openai/gpt-image-1", "bfl/flux-2-pro"]);
   });
 
   test("filters empty segments from trailing comma", () => {
-    const result = resolveModels("image", "openai/gpt-image-1,");
+    const result = resolveModels("image", "openai/gpt-image-1,", undefined, "vercel");
     expect(result).toEqual(["openai/gpt-image-1"]);
   });
 
   test("falls back to default when all segments are empty", () => {
-    const result = resolveModels("image", ",,,");
+    const result = resolveModels("image", ",,,", undefined, "vercel");
     expect(result).toHaveLength(1);
     expect(result[0]).toContain("/");
   });

--- a/packages/ai-cli/src/lib/models.ts
+++ b/packages/ai-cli/src/lib/models.ts
@@ -1,13 +1,29 @@
+import { type Backend } from "./provider.js";
+
 export type Modality = "text" | "image" | "video";
 
-const DEFAULTS: Record<Modality, string> = {
-  text: process.env.AI_CLI_TEXT_MODEL ?? "openai/gpt-5.5",
-  image: process.env.AI_CLI_IMAGE_MODEL ?? "openai/gpt-image-2",
-  video: process.env.AI_CLI_VIDEO_MODEL ?? "bytedance/seedance-2.0",
+const DEFAULTS: Record<Backend, Record<Modality, string>> = {
+  vercel: {
+    text: process.env.AI_CLI_TEXT_MODEL ?? "openai/gpt-5.5",
+    image: process.env.AI_CLI_IMAGE_MODEL ?? "openai/gpt-image-2",
+    video: process.env.AI_CLI_VIDEO_MODEL ?? "bytedance/seedance-2.0",
+  },
+  openrouter: {
+    text: process.env.AI_CLI_TEXT_MODEL ?? "openai/gpt-4o",
+    image: process.env.AI_CLI_IMAGE_MODEL ?? "fal-ai/flux-pro",
+    video: process.env.AI_CLI_VIDEO_MODEL ?? "fal-ai/kling-video/v2.1/standard/text-to-video",
+  },
+  openai: {
+    text: process.env.AI_CLI_TEXT_MODEL ?? "gpt-4o",
+    image: process.env.AI_CLI_IMAGE_MODEL ?? "dall-e-3",
+    video: "",
+  },
+  fal: {
+    text: "",
+    image: process.env.AI_CLI_IMAGE_MODEL ?? "fal-ai/flux-pro",
+    video: process.env.AI_CLI_VIDEO_MODEL ?? "fal-ai/kling-video/v2.1/standard/text-to-video",
+  },
 };
-
-const GATEWAY_MODELS_URL = "https://ai-gateway.vercel.sh/v1/models";
-const GATEWAY_TIMEOUT_MS = 5_000;
 
 export interface ModelPricing {
   input?: string;
@@ -32,25 +48,44 @@ export interface GatewayModels {
   languageImageModelIds: Set<string>;
 }
 
-interface RawGatewayModel {
-  id: string;
-  name?: string;
-  description?: string;
-  owned_by?: string;
-  type?: string;
-  tags?: string[];
-  pricing?: {
-    input?: string;
-    output?: string;
-    image?: string;
-  };
-}
+// fal.ai does not expose a unified model list endpoint; we maintain popular models here.
+const FAL_MODELS: ModelEntry[] = [
+  { id: "fal-ai/flux-pro", name: "FLUX Pro", creator: "fal-ai", capabilities: ["image"] },
+  { id: "fal-ai/flux/schnell", name: "FLUX Schnell (fast)", creator: "fal-ai", capabilities: ["image"] },
+  { id: "fal-ai/flux/dev", name: "FLUX Dev", creator: "fal-ai", capabilities: ["image"] },
+  { id: "fal-ai/flux-realism", name: "FLUX Realism", creator: "fal-ai", capabilities: ["image"] },
+  { id: "fal-ai/stable-diffusion-v3-medium", name: "SD3 Medium", creator: "fal-ai", capabilities: ["image"] },
+  { id: "fal-ai/aura-flow", name: "AuraFlow", creator: "fal-ai", capabilities: ["image"] },
+  { id: "fal-ai/kling-video/v2.1/standard/text-to-video", name: "Kling v2.1 T2V", creator: "fal-ai", capabilities: ["video"] },
+  { id: "fal-ai/kling-video/v2.1/standard/image-to-video", name: "Kling v2.1 I2V", creator: "fal-ai", capabilities: ["video"] },
+  { id: "fal-ai/wan-t2v-v1.3", name: "Wan T2V", creator: "fal-ai", capabilities: ["video"] },
+  { id: "fal-ai/hunyuan-video", name: "HunyuanVideo", creator: "fal-ai", capabilities: ["video"] },
+  { id: "fal-ai/runway-gen3/turbo/text-to-video", name: "Runway Gen3 Turbo T2V", creator: "fal-ai", capabilities: ["video"] },
+];
+
+const OPENAI_MODELS: ModelEntry[] = [
+  { id: "gpt-4o", name: "GPT-4o", creator: "openai", capabilities: ["text"] },
+  { id: "gpt-4o-mini", name: "GPT-4o Mini", creator: "openai", capabilities: ["text"] },
+  { id: "gpt-4.1", name: "GPT-4.1", creator: "openai", capabilities: ["text"] },
+  { id: "o3", name: "o3", creator: "openai", capabilities: ["text"] },
+  { id: "o4-mini", name: "o4-mini", creator: "openai", capabilities: ["text"] },
+  { id: "dall-e-3", name: "DALL-E 3", creator: "openai", capabilities: ["image"] },
+  { id: "dall-e-2", name: "DALL-E 2", creator: "openai", capabilities: ["image"] },
+  { id: "gpt-image-1", name: "GPT Image 1", creator: "openai", capabilities: ["image"] },
+];
 
 let cached: Promise<GatewayModels> | null = null;
+let cachedBackend: Backend | null = null;
 
-export function fetchGatewayModels(): Promise<GatewayModels> {
-  if (!cached) {
-    cached = doFetch().catch((err) => {
+export function resetGatewayCache(): void {
+  cached = null;
+  cachedBackend = null;
+}
+
+export function fetchGatewayModels(backend: Backend = "vercel"): Promise<GatewayModels> {
+  if (!cached || cachedBackend !== backend) {
+    cachedBackend = backend;
+    cached = doFetch(backend).catch((err) => {
       cached = null;
       throw err;
     });
@@ -58,11 +93,47 @@ export function fetchGatewayModels(): Promise<GatewayModels> {
   return cached;
 }
 
-export function resetGatewayCache(): void {
-  cached = null;
+function buildFromList(models: ModelEntry[]): GatewayModels {
+  const result: GatewayModels = {
+    text: [],
+    image: [],
+    video: [],
+    all: [...models],
+    languageImageModelIds: new Set(),
+  };
+  for (const m of models) {
+    if (m.capabilities.includes("text")) result.text.push(m);
+    if (m.capabilities.includes("image")) result.image.push(m);
+    if (m.capabilities.includes("video")) result.video.push(m);
+  }
+  return result;
 }
 
-async function doFetch(): Promise<GatewayModels> {
+interface RawModel {
+  id: string;
+  name?: string;
+  description?: string;
+  owned_by?: string;
+  type?: string;
+  tags?: string[];
+  architecture?: { modality?: string };
+  pricing?: { input?: string; output?: string; image?: string };
+}
+
+async function doFetch(backend: Backend): Promise<GatewayModels> {
+  if (backend === "fal") return buildFromList(FAL_MODELS);
+  if (backend === "openai") return buildFromList(OPENAI_MODELS);
+
+  const url =
+    backend === "openrouter"
+      ? "https://openrouter.ai/api/v1/models"
+      : "https://ai-gateway.vercel.sh/v1/models";
+
+  const authHeader =
+    backend === "openrouter"
+      ? `Bearer ${process.env.OPENROUTER_API_KEY}`
+      : `Bearer ${process.env.AI_GATEWAY_API_KEY}`;
+
   const result: GatewayModels = {
     text: [],
     image: [],
@@ -72,13 +143,13 @@ async function doFetch(): Promise<GatewayModels> {
   };
 
   try {
-    const res = await fetch(GATEWAY_MODELS_URL, {
-      signal: AbortSignal.timeout(GATEWAY_TIMEOUT_MS),
+    const res = await fetch(url, {
+      headers: { Authorization: authHeader },
+      signal: AbortSignal.timeout(5_000),
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const json = (await res.json()) as { data?: RawGatewayModel[] };
+    const json = (await res.json()) as { data?: RawModel[] };
     const models = json.data ?? [];
-
     const entryMap = new Map<string, ModelEntry>();
 
     for (const m of models) {
@@ -86,58 +157,64 @@ async function doFetch(): Promise<GatewayModels> {
       const isImageGen = tags.includes("image-generation");
       const capabilities: Modality[] = [];
 
-      switch (m.type) {
-        case "language":
+      if (backend === "openrouter") {
+        const modality = m.architecture?.modality ?? "";
+        if (modality.includes("image") || modality.includes("vision")) {
           capabilities.push("text");
-          if (isImageGen) capabilities.push("image");
-          break;
-        case "image":
-          capabilities.push("image");
-          break;
-        case "video":
-          capabilities.push("video");
-          break;
-        default:
-          continue;
+        } else {
+          capabilities.push("text");
+        }
+      } else {
+        switch (m.type) {
+          case "language":
+            capabilities.push("text");
+            if (isImageGen) capabilities.push("image");
+            break;
+          case "image":
+            capabilities.push("image");
+            break;
+          case "video":
+            capabilities.push("video");
+            break;
+          default:
+            continue;
+        }
       }
 
-      const creator =
-        m.owned_by ??
-        (m.id.slice(0, Math.max(0, m.id.indexOf("/"))) || "other");
-
+      const creator = m.owned_by ?? (m.id.slice(0, Math.max(0, m.id.indexOf("/"))) || "other");
       const pricing: ModelPricing | undefined =
         m.pricing?.input || m.pricing?.output || m.pricing?.image
           ? {
-              ...(m.pricing.input ? { input: m.pricing.input } : {}),
-              ...(m.pricing.output ? { output: m.pricing.output } : {}),
-              ...(m.pricing.image ? { image: m.pricing.image } : {}),
+              ...(m.pricing?.input ? { input: m.pricing.input } : {}),
+              ...(m.pricing?.output ? { output: m.pricing.output } : {}),
+              ...(m.pricing?.image ? { image: m.pricing.image } : {}),
             }
           : undefined;
 
-      const entry: ModelEntry = {
-        id: m.id,
-        name: m.name,
-        description: m.description,
-        creator,
-        capabilities,
-        pricing,
-      };
-
+      const entry: ModelEntry = { id: m.id, name: m.name, description: m.description, creator, capabilities, pricing };
       entryMap.set(m.id, entry);
 
       if (capabilities.includes("text")) result.text.push(entry);
       if (capabilities.includes("image")) result.image.push(entry);
       if (capabilities.includes("video")) result.video.push(entry);
-
-      if (m.type === "language" && isImageGen) {
-        result.languageImageModelIds.add(m.id);
-      }
+      if (m.type === "language" && isImageGen) result.languageImageModelIds.add(m.id);
     }
 
     result.all = [...entryMap.values()];
   } catch {
     cached = null;
-    process.stderr.write("Warning: could not fetch models from AI Gateway\n");
+    process.stderr.write(
+      `Warning: could not fetch model list from ${backend === "openrouter" ? "OpenRouter" : "Vercel AI Gateway"}\n`
+    );
+  }
+
+  // When using openrouter + fal together, add fal models to the image/video lists
+  if (backend === "openrouter" && process.env.FAL_KEY) {
+    for (const m of FAL_MODELS) {
+      result.all.push(m);
+      if (m.capabilities.includes("image")) result.image.push(m);
+      if (m.capabilities.includes("video")) result.video.push(m);
+    }
   }
 
   return result;
@@ -145,29 +222,34 @@ async function doFetch(): Promise<GatewayModels> {
 
 export function resolveModels(
   modality: Modality,
-  userModel?: string,
-  knownModels?: Pick<ModelEntry, "id">[]
+  userModel: string | undefined,
+  knownModels: Pick<ModelEntry, "id">[] | undefined,
+  backend: Backend = "vercel"
 ): string[] {
-  if (!userModel) return [DEFAULTS[modality]];
+  const defaultModel = DEFAULTS[backend][modality];
+  if (!userModel) {
+    if (!defaultModel) {
+      process.stderr.write(
+        `Error: ${modality} generation is not supported with the "${backend}" backend.\n`
+      );
+      process.exit(1);
+    }
+    return [defaultModel];
+  }
   const models = userModel
     .split(",")
     .map((m) => m.trim())
     .filter(Boolean)
     .map((m) => expandModelId(m, knownModels));
-  return models.length > 0 ? models : [DEFAULTS[modality]];
+  return models.length > 0 ? models : [defaultModel];
 }
 
-function expandModelId(
-  input: string,
-  knownModels?: Pick<ModelEntry, "id">[]
-): string {
+function expandModelId(input: string, knownModels?: Pick<ModelEntry, "id">[]): string {
   if (input.includes("/")) return input;
   if (!knownModels) return input;
-
   for (const m of knownModels) {
     const name = m.id.slice(m.id.indexOf("/") + 1);
     if (name === input) return m.id;
   }
-
   return input;
 }

--- a/packages/ai-cli/src/lib/provider.ts
+++ b/packages/ai-cli/src/lib/provider.ts
@@ -1,0 +1,115 @@
+import {
+  gateway,
+  type LanguageModel,
+  type ImageModel,
+} from "ai";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { createOpenAI } from "@ai-sdk/openai";
+import { fal } from "@ai-sdk/fal";
+
+export type Backend = "vercel" | "openrouter" | "openai" | "fal";
+
+export interface Provider {
+  backend: Backend;
+  text: (modelId: string) => LanguageModel;
+  image: (modelId: string) => ImageModel;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  video: ((modelId: string) => any) | null;
+}
+
+export function detectBackend(): Backend {
+  const explicit = process.env.AI_PROVIDER as Backend | undefined;
+  if (explicit) return explicit;
+
+  if (process.env.AI_GATEWAY_API_KEY) return "vercel";
+  if (process.env.FAL_KEY && process.env.OPENROUTER_API_KEY) return "openrouter"; // openrouter handles text; fal handles media
+  if (process.env.OPENROUTER_API_KEY) return "openrouter";
+  if (process.env.FAL_KEY) return "fal";
+  if (process.env.OPENAI_API_KEY) return "openai";
+
+  process.stderr.write(
+    [
+      "Error: no API key found. Set one of:",
+      "  AI_GATEWAY_API_KEY   — Vercel AI Gateway (text + image + video, 100+ models)",
+      "  OPENROUTER_API_KEY   — OpenRouter (text, 300+ models)",
+      "  FAL_KEY              — fal.ai (image + video)",
+      "  OPENAI_API_KEY       — OpenAI direct (text + DALL-E image)",
+      "  OPENROUTER_API_KEY + FAL_KEY — text via OpenRouter, image/video via fal.ai",
+      "",
+    ].join("\n")
+  );
+  process.exit(1);
+}
+
+export function createProvider(): Provider {
+  const backend = detectBackend();
+
+  // ── Vercel AI Gateway (default, all capabilities) ──────────────────────────
+  if (backend === "vercel") {
+    return {
+      backend,
+      text: (id) => gateway(id),
+      image: (id) => gateway.image(id),
+      video: (id) => gateway.video(id),
+    };
+  }
+
+  // ── OpenRouter (text only; pair with FAL_KEY for image/video) ──────────────
+  if (backend === "openrouter") {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY!,
+      headers: {
+        "HTTP-Referer": "https://github.com/vercel-labs/ai-cli",
+        "X-Title": "ai-cli",
+      },
+    });
+
+    // If user also has FAL_KEY, route image/video to fal.ai automatically
+    const hasFal = Boolean(process.env.FAL_KEY);
+
+    return {
+      backend,
+      text: (id) => openrouter(id) as LanguageModel,
+      image: hasFal
+        ? (id) => fal.image(id)
+        : () => {
+            process.stderr.write(
+              "Error: image generation requires FAL_KEY. Set FAL_KEY to use fal.ai for images, or use AI_GATEWAY_API_KEY for all-in-one access.\n"
+            );
+            process.exit(1);
+          },
+      video: hasFal
+        ? (id) => fal.video(id)
+        : null,
+    };
+  }
+
+  // ── fal.ai (image + video; no text) ────────────────────────────────────────
+  if (backend === "fal") {
+    return {
+      backend,
+      text: () => {
+        process.stderr.write(
+          "Error: text generation requires OPENROUTER_API_KEY or AI_GATEWAY_API_KEY. fal.ai handles image/video only.\n"
+        );
+        process.exit(1);
+      },
+      image: (id) => fal.image(id),
+      video: (id) => fal.video(id),
+    };
+  }
+
+  // ── OpenAI direct (text + DALL-E image; no video) ──────────────────────────
+  if (backend === "openai") {
+    const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+    return {
+      backend,
+      text: (id) => openai(id),
+      image: (id) => openai.image(id),
+      video: null,
+    };
+  }
+
+  process.stderr.write(`Error: unknown backend "${backend}"\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## What this adds

A provider abstraction layer that lets `ai-cli` work without a Vercel AI Gateway key, by supporting OpenRouter, fal.ai, and direct OpenAI as backends.

## Motivation

Getting a Vercel AI Gateway key requires a Vercel account. Many users already have OpenRouter or OpenAI API keys. This change lets them use `ai-cli` immediately with what they have.

## How it works

Auto-detects the active backend from environment variables. Vercel AI Gateway remains the default — existing behaviour is unchanged.

| Env vars set | Text | Image | Video |
|---|---|---|---|
| `AI_GATEWAY_API_KEY` | ✓ Vercel (100+ models) | ✓ | ✓ |
| `OPENROUTER_API_KEY` | ✓ OpenRouter (300+ models) | — | — |
| `OPENROUTER_API_KEY` + `FAL_KEY` | ✓ OpenRouter | ✓ fal.ai (Flux, SDXL) | ✓ fal.ai (Kling, Wan, Runway) |
| `FAL_KEY` | — | ✓ fal.ai | ✓ fal.ai |
| `OPENAI_API_KEY` | ✓ GPT models | ✓ DALL-E | — |
| `AI_PROVIDER=<backend>` | explicit override | — | — |

## Changes

**New file: `src/lib/provider.ts`**
- `detectBackend()` — reads env vars, returns active backend
- `createProvider()` — returns `{ text(), image(), video() }` factory functions pointing to the right AI SDK provider

**`src/lib/models.ts`**
- `fetchGatewayModels(backend)` — fetches models from the right source
- OpenRouter: live from `openrouter.ai/api/v1/models`
- fal.ai: static catalogue (Flux, Kling, Wan, HunyuanVideo, Runway Gen3) — fal.ai has no public model list endpoint
- OpenAI: static catalogue (GPT-4o, o3, o4-mini, DALL-E 2/3, GPT Image 1)
- `resolveModels(modality, model, known, backend)` — selects correct defaults per backend

**`src/commands/text.ts`, `image.ts`, `video.ts`, `models.ts`**
- All commands call `createProvider()` and use `provider.text/image/video(modelId)`
- `video.ts` exits with a clear message if backend has no video support
- `image.ts` language-image path (GPT-4o with image output) is guarded to Vercel gateway only

**New dependencies**
- `@openrouter/ai-sdk-provider` v2.9.0
- `@ai-sdk/openai` v3.0.58
- `@ai-sdk/fal` v2.0.33

## Testing status

- [x] TypeScript type-checks clean (`tsc --noEmit`)
- [x] CLI starts and all `--help` pages render correctly
- [x] Provider package APIs verified at runtime (`fal.image`, `fal.video`, `openrouter()` all confirmed callable with correct signatures)
- [ ] End-to-end generation via OpenRouter (not tested with live key — wiring is correct based on package API verification)
- [ ] End-to-end generation via fal.ai (not tested with live key — wiring is correct based on package API verification)
- [x] Vercel AI Gateway path: unchanged, all existing tests pass

Happy to add end-to-end tests or adjust the approach based on feedback. If the project prefers to keep the tool Vercel-specific, I understand — just thought this was worth proposing given how often it comes up for first-time users.