### PR TITLE
Fix ai-cli global install runtime

### DIFF
--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -8,7 +8,7 @@ A tiny, agent-native CLI for generating images, video and text with dead-simple 
 npm install -g ai-cli
 ```
 
-Requires an [AI Gateway](https://vercel.com/docs/ai-gateway) API key or a provider-specific key (e.g. `OPENAI_API_KEY`).
+Requires Node.js 20+ and an [AI Gateway](https://vercel.com/docs/ai-gateway) API key or a provider-specific key (e.g. `OPENAI_API_KEY`).
 
 ## Usage
 

--- a/packages/ai-cli/package.json
+++ b/packages/ai-cli/package.json
@@ -8,11 +8,14 @@
     "type": "git",
     "url": "https://github.com/vercel-labs/ai-cli.git"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "bin": {
-    "ai": "./src/index.ts"
+    "ai": "./dist/index.js"
   },
   "files": [
-    "src",
+    "dist",
     "README.md"
   ],
   "keywords": [
@@ -27,13 +30,14 @@
   ],
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "bun build src/index.ts --compile --outfile=dist/ai",
+    "clean": "bun -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "build": "bun run clean && bun build src/index.ts --target=node --outdir=dist",
     "typecheck": "tsc --noEmit",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/",
     "lint": "oxlint src/",
     "test": "bun test",
-    "prepublishOnly": "bun run typecheck"
+    "prepack": "bun run typecheck && bun run build"
   },
   "dependencies": {
     "ai": "^6.0.173",

--- a/packages/ai-cli/src/cli.test.ts
+++ b/packages/ai-cli/src/cli.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import pkg from "../package.json";
+
 const CLI = ["bun", "run", "src/index.ts"];
 const ROOT = import.meta.dir + "/..";
 
@@ -19,6 +21,12 @@ async function run(...args: string[]) {
 }
 
 describe("cli integration", () => {
+  test("published bin targets built JavaScript", () => {
+    expect(pkg.bin.ai).toBe("./dist/index.js");
+    expect(pkg.files).toContain("dist");
+    expect(pkg.files).not.toContain("src");
+  });
+
   test("--help exits 0 and lists subcommands", async () => {
     const { exitCode, stdout } = await run("--help");
     expect(exitCode).toBe(0);

--- a/packages/ai-cli/src/index.ts
+++ b/packages/ai-cli/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 import { Command } from "commander";
 
 import pkg from "../package.json";


### PR DESCRIPTION
## Summary
- Publish the `ai` bin from a Node-targeted `dist/index.js` bundle instead of TypeScript source.
- Build the package during `prepack` so published tarballs include the executable bundle and WASM asset.
- Document the Node.js runtime requirement and add a regression test for the package bin target.