### PR TITLE
prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.2.1
+
+<!-- release:start -->
+
+### Bug Fixes
+
+- **Published CLI binary** — packages `ai` as a Node-targeted `dist/index.js` bundle and points npm's `bin`/`files` metadata at `dist`, fixing global installs that could not execute the TypeScript source (#52)
+
+### Improvements
+
+- **Node engine requirement** — declares and documents the Node.js 20+ runtime requirement for the CLI package (#52)
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
 ## 0.2.0
 
 <!-- release:start -->

--- a/packages/ai-cli/package.json
+++ b/packages/ai-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A tiny, agent-native CLI for generating images, video and text with dead-simple commands, stdin support and predictable artifact outputs",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Bumps `ai-cli` to `0.2.1` for the patch release.
- Adds changelog notes for the published CLI binary fix and Node engine requirement from #52.