### PR TITLE
fix(cli): coerce leading numeric flag values (e.g. `1.5s` → `1.5`)

### DIFF
--- a/packages/ai-cli/src/lib/parse.test.ts
+++ b/packages/ai-cli/src/lib/parse.test.ts
@@ -59,6 +59,12 @@ describe("parseNonNegativeFloat", () => {
     );
   });
 
+  test("rejects string with trailing non-numeric characters", () => {
+    expect(() => parseNonNegativeFloat("1.5s", "duration")).toThrow(
+      "non-negative"
+    );
+  });
+
   test("includes flag name in error", () => {
     expect(() => parseNonNegativeFloat("bad", "temperature")).toThrow(
       "--temperature"
@@ -110,5 +116,9 @@ describe("parseTemperature", () => {
 
   test("rejects non-numeric", () => {
     expect(() => parseTemperature("abc")).toThrow("between 0 and 2");
+  });
+
+  test("rejects string with trailing non-numeric characters", () => {
+    expect(() => parseTemperature("1abc")).toThrow("between 0 and 2");
   });
 });

--- a/packages/ai-cli/src/lib/parse.test.ts
+++ b/packages/ai-cli/src/lib/parse.test.ts
@@ -59,10 +59,9 @@ describe("parseNonNegativeFloat", () => {
     );
   });
 
-  test("rejects string with trailing non-numeric characters", () => {
-    expect(() => parseNonNegativeFloat("1.5s", "duration")).toThrow(
-      "non-negative"
-    );
+  test("coerces a leading number, dropping trailing non-numeric characters", () => {
+    expect(parseNonNegativeFloat("1.5s", "duration")).toBe(1.5);
+    expect(parseNonNegativeFloat("2ms", "duration")).toBe(2);
   });
 
   test("includes flag name in error", () => {
@@ -118,7 +117,8 @@ describe("parseTemperature", () => {
     expect(() => parseTemperature("abc")).toThrow("between 0 and 2");
   });
 
-  test("rejects string with trailing non-numeric characters", () => {
-    expect(() => parseTemperature("1abc")).toThrow("between 0 and 2");
+  test("coerces a leading number, dropping trailing non-numeric characters", () => {
+    expect(parseTemperature("1abc")).toBe(1);
+    expect(parseTemperature("1.5s")).toBe(1.5);
   });
 });

--- a/packages/ai-cli/src/lib/parse.ts
+++ b/packages/ai-cli/src/lib/parse.ts
@@ -10,10 +10,14 @@ export function parsePositiveInt(value: string, name: string): number {
 }
 
 function parseDecimal(value: string): number | null {
-  if (!/^(?:\d+(?:\.\d*)?|\.\d+)$/.test(value)) {
+  // Require a leading decimal number, then let parseFloat extract it, so
+  // values like "1.5s" coerce to 1.5 while "abc" (no leading number) is
+  // rejected. The regexp keeps parseFloat from being too permissive.
+  if (!/^\s*-?(?:\d+(?:\.\d*)?|\.\d+)/.test(value)) {
     return null;
   }
-  return Number(value);
+  const n = Number.parseFloat(value);
+  return Number.isNaN(n) ? null : n;
 }
 
 export function parseNonNegativeFloat(value: string, name: string): number {

--- a/packages/ai-cli/src/lib/parse.ts
+++ b/packages/ai-cli/src/lib/parse.ts
@@ -9,9 +9,16 @@ export function parsePositiveInt(value: string, name: string): number {
   return n;
 }
 
+function parseDecimal(value: string): number | null {
+  if (!/^(?:\d+(?:\.\d*)?|\.\d+)$/.test(value)) {
+    return null;
+  }
+  return Number(value);
+}
+
 export function parseNonNegativeFloat(value: string, name: string): number {
-  const n = parseFloat(value);
-  if (isNaN(n) || n < 0) {
+  const n = parseDecimal(value);
+  if (n === null || n < 0) {
     throw new Error(`--${name} must be a non-negative number, got "${value}"`);
   }
   return n;
@@ -36,8 +43,8 @@ export function parseAspectRatio(value: string): `${number}:${number}` {
 }
 
 export function parseTemperature(value: string): number {
-  const n = parseFloat(value);
-  if (isNaN(n) || n < 0 || n > 2) {
+  const n = parseDecimal(value);
+  if (n === null || n < 0 || n > 2) {
     throw new Error(`--temperature must be between 0 and 2, got "${value}"`);
   }
   return n;


### PR DESCRIPTION
## Summary
Addresses @atinux's review: instead of rejecting partial numeric values, coerce the leading number (parseFloat-style) so `--temperature 1.5s` / `--duration 2ms` work (→ `1.5` / `2`). A leading-number regexp keeps `parseFloat` from being too permissive, so values with **no** leading number (e.g. `abc`) are still rejected.

## Behavior
- `1.5s` → `1.5`, `1abc` → `1`, `.5x` → `0.5`
- `abc` (no leading number) → still errors
- negatives / out-of-range still rejected downstream

## Tests
- `bun test packages/ai-cli/src/lib/parse.test.ts` (20 pass)
- `bun run typecheck`
- `bun run format:check`