### PR TITLE
Add image references to CLI

### DIFF
--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -19,10 +19,14 @@ ai text "explain quantum computing"
 ai models                          # list available models
 ```
 
-### Piping
+### Piping and References
 
 ```bash
 ai image "a dragon" | ai video "animate this"
+ai image --image reference.png "make a sticker in this style"
+ai image -i sketch.png -i palette.jpg "render this product concept"
+ai text --image screenshot.png "what is broken in this UI?"
+cat photo.png | ai text "describe this image"
 cat notes.txt | ai text "summarize this"
 git diff | ai text "explain these changes"
 ```
@@ -50,12 +54,21 @@ ai image -m flux-2-pro "a sunset"   # resolves to bfl/flux-2-pro
 ### image
 
 ```
+-i, --image <path-or-url> Reference image path or URL (repeatable)
 --size <WxH>             Image size (e.g. 1024x1024)
 --aspect-ratio <W:H>     Aspect ratio (e.g. 16:9)
 --quality <level>        Quality (standard, hd)
 --style <style>          Style (vivid, natural)
 --no-preview             Disable inline image preview
 ```
+
+Reference images can be local paths, `file://` URLs, `http(s)://` URLs or data URLs. You can repeat `--image` to pass multiple references, and you can still pipe one image through stdin:
+
+```bash
+cat input.png | ai image -i style.png "combine the subject with this style"
+```
+
+Reference-image support is model-dependent; unsupported models may reject image inputs.
 
 ### video
 
@@ -69,9 +82,17 @@ ai image -m flux-2-pro "a sunset"   # resolves to bfl/flux-2-pro
 
 ```
 -f, --format <fmt>       Output format: md, txt (default: md)
+-i, --image <path-or-url> Image input path or URL for vision (repeatable)
 -s, --system <prompt>    System prompt
 --max-tokens <n>         Maximum tokens to generate
 -t, --temperature <n>    Temperature (0-2)
+```
+
+For vision-capable text models, `ai text` accepts images from `--image` or piped stdin:
+
+```bash
+ai text -i chart.png -i table.jpg "summarize the data"
+cat screenshot.png | ai text "list the visible errors"
 ```
 
 ### models

--- a/packages/ai-cli/src/cli.test.ts
+++ b/packages/ai-cli/src/cli.test.ts
@@ -44,7 +44,7 @@ describe("cli integration", () => {
   test("text with no prompt and no stdin exits 1", async () => {
     const { exitCode, stderr } = await run("text");
     expect(exitCode).toBe(1);
-    expect(stderr).toContain("prompt is required");
+    expect(stderr).toContain("prompt, stdin, or image is required");
   });
 
   test("text --help exits 0 and lists flags", async () => {
@@ -52,6 +52,7 @@ describe("cli integration", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("--model");
     expect(stdout).toContain("--format");
+    expect(stdout).toContain("--image");
     expect(stdout).toContain("--temperature");
   });
 
@@ -59,6 +60,7 @@ describe("cli integration", () => {
     const { exitCode, stdout } = await run("image", "--help");
     expect(exitCode).toBe(0);
     expect(stdout).toContain("--no-preview");
+    expect(stdout).toContain("--image");
     expect(stdout).toContain("--size");
     expect(stdout).toContain("--aspect-ratio");
   });

--- a/packages/ai-cli/src/commands/image.ts
+++ b/packages/ai-cli/src/commands/image.ts
@@ -1,6 +1,11 @@
 import { generateImage, generateText, gateway } from "ai";
 import type { Command } from "commander";
 
+import {
+  collectImageReference,
+  loadImageReferences,
+  type ImageReference,
+} from "../lib/image-references.js";
 import { buildJobs, runJobs } from "../lib/jobs.js";
 import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import { parsePositiveInt, parseSize, parseAspectRatio } from "../lib/parse.js";
@@ -12,6 +17,7 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 interface ImageOptions {
   model?: string;
   output?: string;
+  image?: string[];
   count?: string;
   size?: string;
   aspectRatio?: string;
@@ -33,6 +39,12 @@ export function registerImageCommand(program: Command) {
       "Model ID (creator/model-name), comma-separated for multi-model"
     )
     .option("-o, --output <path>", "Output file path or directory")
+    .option(
+      "-i, --image <path-or-url>",
+      "Reference image path or URL (repeatable)",
+      collectImageReference,
+      []
+    )
     .option("-n, --count <n>", "Number of images per model (default: 1)")
     .option("--size <WxH>", "Image size (e.g. 1024x1024)")
     .option("--aspect-ratio <W:H>", "Aspect ratio (e.g. 16:9)")
@@ -51,17 +63,31 @@ export function registerImageCommand(program: Command) {
     .action(async (rawPrompt: string | undefined, opts: ImageOptions) => {
       const prompt = rawPrompt?.trim() || undefined;
       const stdin = await readStdin();
-      if (!prompt && !stdin) {
+      const imageReferenceInputs = opts.image ?? [];
+      if (!prompt && !stdin && imageReferenceInputs.length === 0) {
         process.stderr.write(
-          "Error: prompt is required (provide as argument or pipe via stdin)\n"
+          "Error: prompt or reference image is required (provide a prompt, --image, or pipe an image via stdin)\n"
         );
         process.exit(1);
       }
-      let imagePrompt: string | { images: Uint8Array[]; text?: string };
-      if (stdin) {
-        imagePrompt = prompt
-          ? { images: [new Uint8Array(stdin)], text: prompt }
-          : { images: [new Uint8Array(stdin)] };
+
+      let referenceImages: ImageReference[] = [];
+      try {
+        referenceImages = await loadImageReferences(imageReferenceInputs);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`Error: ${message}\n`);
+        process.exit(1);
+      }
+
+      const images: ImageReference[] = [
+        ...(stdin ? [new Uint8Array(stdin)] : []),
+        ...referenceImages,
+      ];
+
+      let imagePrompt: string | { images: ImageReference[]; text?: string };
+      if (images.length > 0) {
+        imagePrompt = prompt ? { images, text: prompt } : { images };
       } else {
         imagePrompt = prompt!;
       }
@@ -96,7 +122,7 @@ export function registerImageCommand(program: Command) {
           if (gatewayModels.languageImageModelIds.has(modelId)) {
             const messageContent: Array<
               | { type: "text"; text: string }
-              | { type: "image"; image: Uint8Array }
+              | { type: "image"; image: ImageReference }
             > = [];
             if (typeof imagePrompt === "string") {
               messageContent.push({ type: "text", text: imagePrompt });

--- a/packages/ai-cli/src/commands/text.ts
+++ b/packages/ai-cli/src/commands/text.ts
@@ -1,6 +1,18 @@
-import { generateText, gateway } from "ai";
+import {
+  generateText,
+  gateway,
+  type ImagePart,
+  type ModelMessage,
+  type TextPart,
+} from "ai";
 import type { Command } from "commander";
 
+import {
+  collectImageReference,
+  isLikelyImage,
+  loadImageReferences,
+  type ImageReference,
+} from "../lib/image-references.js";
 import { buildJobs, runJobs } from "../lib/jobs.js";
 import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import type { OutputFormat } from "../lib/output.js";
@@ -14,6 +26,7 @@ interface TextOptions {
   model?: string;
   output?: string;
   format?: string;
+  image?: string[];
   system?: string;
   maxTokens?: string;
   temperature?: string;
@@ -22,6 +35,8 @@ interface TextOptions {
   quiet?: boolean;
   json?: boolean;
 }
+
+type TextPrompt = string | ModelMessage[];
 
 function resolveFormat(fmt?: string): OutputFormat {
   if (!fmt || fmt === "md") return "md";
@@ -40,6 +55,12 @@ export function registerTextCommand(program: Command) {
     )
     .option("-o, --output <path>", "Output file path or directory")
     .option("-f, --format <fmt>", "Output format: md, txt (default: md)")
+    .option(
+      "-i, --image <path-or-url>",
+      "Image input path or URL for vision (repeatable)",
+      collectImageReference,
+      []
+    )
     .option("-n, --count <n>", "Number of generations (default: 1)")
     .option(
       "-p, --concurrency <n>",
@@ -53,20 +74,31 @@ export function registerTextCommand(program: Command) {
     .action(async (rawPrompt: string | undefined, opts: TextOptions) => {
       const prompt = rawPrompt?.trim() || undefined;
       const stdin = await readStdin();
-      if (!prompt && !stdin) {
+      const imageReferenceInputs = opts.image ?? [];
+      if (!prompt && !stdin && imageReferenceInputs.length === 0) {
         process.stderr.write(
-          "Error: prompt is required (provide as argument or pipe via stdin)\n"
+          "Error: prompt, stdin, or image is required (provide a prompt, --image, or pipe text/image via stdin)\n"
         );
         process.exit(1);
       }
-      let fullPrompt: string;
-      if (stdin && prompt) {
-        fullPrompt = `${stdinAsText(stdin)}\n\n---\n\n${prompt}`;
-      } else if (stdin) {
-        fullPrompt = stdinAsText(stdin);
-      } else {
-        fullPrompt = prompt!;
+
+      let referenceImages: ImageReference[] = [];
+      try {
+        referenceImages = await loadImageReferences(imageReferenceInputs);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`Error: ${message}\n`);
+        process.exit(1);
       }
+
+      const stdinBytes = stdin ? new Uint8Array(stdin) : undefined;
+      const stdinIsImage = stdinBytes ? isLikelyImage(stdinBytes) : false;
+      const images: ImageReference[] = [
+        ...(stdinBytes && stdinIsImage ? [stdinBytes] : []),
+        ...referenceImages,
+      ];
+      const stdinText = stdin && !stdinIsImage ? stdinAsText(stdin) : undefined;
+      const textPrompt = buildTextPrompt({ prompt, stdinText, images });
 
       const format = resolveFormat(opts.format);
       const gatewayModels = await fetchGatewayModels();
@@ -93,7 +125,7 @@ export function registerTextCommand(program: Command) {
               "x-title": "ai-cli",
             },
             model: gateway(modelId),
-            prompt: fullPrompt,
+            prompt: textPrompt,
             system: opts.system,
             maxOutputTokens: maxTokens,
             temperature,
@@ -115,4 +147,36 @@ export function registerTextCommand(program: Command) {
       if (failed === total) process.exit(1);
       if (failed > 0) process.exit(2);
     });
+}
+
+function buildTextPrompt({
+  prompt,
+  stdinText,
+  images,
+}: {
+  prompt?: string;
+  stdinText?: string;
+  images: ImageReference[];
+}): TextPrompt {
+  if (images.length === 0) {
+    if (stdinText && prompt) return `${stdinText}\n\n---\n\n${prompt}`;
+    if (stdinText) return stdinText;
+    return prompt!;
+  }
+
+  const content: Array<TextPart | ImagePart> = [];
+
+  if (stdinText) content.push({ type: "text", text: stdinText });
+  for (const image of images) content.push({ type: "image", image });
+  if (prompt) {
+    content.push({ type: "text", text: prompt });
+  } else if (!stdinText) {
+    content.push({
+      type: "text",
+      text:
+        images.length === 1 ? "Describe this image." : "Describe these images.",
+    });
+  }
+
+  return [{ role: "user", content }];
 }

--- a/packages/ai-cli/src/lib/image-references.test.ts
+++ b/packages/ai-cli/src/lib/image-references.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  collectImageReference,
+  isLikelyImage,
+  loadImageReferences,
+} from "./image-references.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+describe("collectImageReference", () => {
+  test("collects repeated values", () => {
+    expect(collectImageReference("a.png")).toEqual(["a.png"]);
+    expect(collectImageReference("b.png", ["a.png"])).toEqual([
+      "a.png",
+      "b.png",
+    ]);
+  });
+});
+
+describe("loadImageReferences", () => {
+  test("loads local image files", async () => {
+    const file = await makeTempFile([1, 2, 3]);
+    const [image] = await loadImageReferences([file]);
+
+    expect(Array.from(image as Uint8Array)).toEqual([1, 2, 3]);
+  });
+
+  test("loads file URLs", async () => {
+    const file = await makeTempFile([4, 5, 6]);
+    const [image] = await loadImageReferences([pathToFileURL(file).href]);
+
+    expect(Array.from(image as Uint8Array)).toEqual([4, 5, 6]);
+  });
+
+  test("passes remote and data URLs through to the SDK", async () => {
+    await expect(
+      loadImageReferences([
+        "HTTPS://EXAMPLE.COM/ref.png",
+        "data:image/png;base64,AAAA",
+      ])
+    ).resolves.toEqual([
+      "https://example.com/ref.png",
+      "data:image/png;base64,AAAA",
+    ]);
+  });
+
+  test("rejects unsupported URL schemes", async () => {
+    await expect(
+      loadImageReferences(["ftp://example.com/ref.png"])
+    ).rejects.toThrow("unsupported reference image URL scheme");
+  });
+
+  test("rejects empty references", async () => {
+    await expect(loadImageReferences(["  "])).rejects.toThrow(
+      "--image cannot be empty"
+    );
+  });
+});
+
+describe("isLikelyImage", () => {
+  test("detects common binary image formats", () => {
+    expect(isLikelyImage(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1]))).toBe(
+      false
+    );
+    expect(
+      isLikelyImage(
+        new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00])
+      )
+    ).toBe(true);
+    expect(isLikelyImage(new Uint8Array([0xff, 0xd8, 0xff, 0xe0]))).toBe(true);
+    expect(isLikelyImage(new TextEncoder().encode("GIF89a"))).toBe(true);
+    expect(isLikelyImage(new TextEncoder().encode("RIFFxxxxWEBP"))).toBe(true);
+  });
+
+  test("detects iso image brands and svg text", () => {
+    expect(isLikelyImage(new TextEncoder().encode("....ftypavif"))).toBe(true);
+    expect(isLikelyImage(new TextEncoder().encode("  <svg></svg>"))).toBe(true);
+  });
+
+  test("does not treat ordinary text as an image", () => {
+    expect(isLikelyImage(new TextEncoder().encode("summarize this"))).toBe(
+      false
+    );
+  });
+});
+
+async function makeTempFile(bytes: number[]): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "ai-cli-image-reference-"));
+  tempDirs.push(dir);
+  const file = join(dir, "ref.png");
+  await writeFile(file, new Uint8Array(bytes));
+  return file;
+}

--- a/packages/ai-cli/src/lib/image-references.ts
+++ b/packages/ai-cli/src/lib/image-references.ts
@@ -1,0 +1,137 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+export type ImageReference = string | Uint8Array;
+
+export function collectImageReference(
+  value: string,
+  previous: string[] = []
+): string[] {
+  return [...previous, value];
+}
+
+export async function loadImageReferences(
+  references: string[]
+): Promise<ImageReference[]> {
+  return Promise.all(references.map(loadImageReference));
+}
+
+export function isLikelyImage(data: Uint8Array): boolean {
+  if (hasPrefix(data, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return true;
+  }
+
+  if (hasPrefix(data, [0xff, 0xd8, 0xff])) return true;
+  if (startsWithAscii(data, "GIF87a") || startsWithAscii(data, "GIF89a")) {
+    return true;
+  }
+
+  if (
+    startsWithAscii(data, "RIFF") &&
+    data.length >= 12 &&
+    asciiAt(data, 8, 4) === "WEBP"
+  ) {
+    return true;
+  }
+
+  if (startsWithAscii(data, "BM")) return true;
+  if (hasPrefix(data, [0x49, 0x49, 0x2a, 0x00])) return true;
+  if (hasPrefix(data, [0x4d, 0x4d, 0x00, 0x2a])) return true;
+  if (hasIsoImageBrand(data)) return true;
+  if (looksLikeSvg(data)) return true;
+
+  return false;
+}
+
+async function loadImageReference(reference: string): Promise<ImageReference> {
+  const trimmed = reference.trim();
+  if (!trimmed) {
+    throw new Error("--image cannot be empty");
+  }
+
+  const url = parseReferenceUrl(trimmed);
+  if (url) {
+    if (url.protocol === "http:" || url.protocol === "https:")
+      return url.toString();
+    if (url.protocol === "data:") return url.toString();
+    if (url.protocol === "file:") return readReferenceFile(fileURLToPath(url));
+
+    throw new Error(
+      `unsupported reference image URL scheme "${url.protocol}"; use a file path, file:// URL, http(s) URL, or data URL`
+    );
+  }
+
+  return readReferenceFile(trimmed);
+}
+
+async function readReferenceFile(path: string): Promise<Uint8Array> {
+  try {
+    return new Uint8Array(await readFile(path));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`could not read reference image "${path}": ${message}`);
+  }
+}
+
+function parseReferenceUrl(input: string): URL | null {
+  if (/^[a-zA-Z]:[\\/]/.test(input)) return null;
+  const lowerInput = input.toLowerCase();
+  if (
+    !lowerInput.startsWith("data:") &&
+    !/^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(input)
+  ) {
+    return null;
+  }
+
+  try {
+    return new URL(input);
+  } catch {
+    return null;
+  }
+}
+
+function hasPrefix(data: Uint8Array, prefix: number[]): boolean {
+  return prefix.every((byte, index) => data[index] === byte);
+}
+
+function startsWithAscii(data: Uint8Array, value: string): boolean {
+  return asciiAt(data, 0, value.length) === value;
+}
+
+function asciiAt(data: Uint8Array, offset: number, length: number): string {
+  if (data.length < offset + length) return "";
+  return String.fromCharCode(...data.slice(offset, offset + length));
+}
+
+function hasIsoImageBrand(data: Uint8Array): boolean {
+  if (data.length < 12 || asciiAt(data, 4, 4) !== "ftyp") return false;
+
+  const brands = new Set([
+    "avif",
+    "avis",
+    "heic",
+    "heix",
+    "hevc",
+    "hevx",
+    "mif1",
+    "msf1",
+  ]);
+
+  for (let offset = 8; offset + 4 <= Math.min(data.length, 64); offset += 4) {
+    if (brands.has(asciiAt(data, offset, 4))) return true;
+  }
+
+  return false;
+}
+
+function looksLikeSvg(data: Uint8Array): boolean {
+  const prefix = new TextDecoder()
+    .decode(data.slice(0, Math.min(data.length, 512)))
+    .trimStart()
+    .toLowerCase();
+
+  return (
+    prefix.startsWith("<svg") ||
+    (prefix.startsWith("<?xml") && prefix.includes("<svg"))
+  );
+}


### PR DESCRIPTION
- Add repeatable image inputs for generation and text vision flows
- Detect piped image stdin while preserving text stdin behavior
- Document usage and cover reference loading with tests