### PR TITLE
prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.3.0
+
+<!-- release:start -->
+
+### New Features
+
+- **Reference image inputs** — `ai image` and `ai text` now accept repeatable `--image` references from local paths, `file://` URLs, `http(s)://` URLs and data URLs
+- **Vision stdin detection** — `ai text` can distinguish piped image bytes from piped text, enabling image prompts from stdin without treating binary data as prompt text
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
 ## 0.2.1
 
 <!-- release:start -->

--- a/packages/ai-cli/package.json
+++ b/packages/ai-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-cli",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A tiny, agent-native CLI for generating images, video and text with dead-simple commands, stdin support and predictable artifact outputs",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Bump ai-cli package version to 0.3.0.
- Add release notes for reference image inputs and vision stdin detection.