### PR TITLE
Add image input flag for video generation

### DIFF
--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -23,6 +23,7 @@ ai models                          # list available models
 
 ```bash
 ai image "a dragon" | ai video "animate this"
+ai video -i input.png "animate this"
 ai image --image reference.png "make a sticker in this style"
 ai image -i sketch.png -i palette.jpg "render this product concept"
 ai text --image screenshot.png "what is broken in this UI?"
@@ -73,9 +74,17 @@ Reference-image support is model-dependent; unsupported models may reject image 
 ### video
 
 ```
+-i, --image <path-or-url> Image input path or URL
 --aspect-ratio <W:H>     Aspect ratio (e.g. 16:9)
 --duration <seconds>     Duration in seconds
 --no-preview             Disable inline video frame preview
+```
+
+Image inputs can be local paths, `file://` URLs, `http(s)://` URLs or data URLs. Video generation accepts one input image, provided either through `--image` or piped stdin:
+
+```bash
+ai video -i input.png "animate this"
+cat input.png | ai video "animate this"
 ```
 
 ### text

--- a/packages/ai-cli/src/cli.test.ts
+++ b/packages/ai-cli/src/cli.test.ts
@@ -68,8 +68,22 @@ describe("cli integration", () => {
   test("video --help exits 0 and lists flags", async () => {
     const { exitCode, stdout } = await run("video", "--help");
     expect(exitCode).toBe(0);
+    expect(stdout).toContain("--image");
     expect(stdout).toContain("--duration");
     expect(stdout).toContain("--aspect-ratio");
+  });
+
+  test("video -i validates image paths before generation", async () => {
+    const { exitCode, stderr } = await run(
+      "video",
+      "-i",
+      "/missing/ref.png",
+      "animate this"
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain(
+      'could not read reference image "/missing/ref.png"'
+    );
   });
 
   test("models --type invalid exits 1", async () => {

--- a/packages/ai-cli/src/commands/video.ts
+++ b/packages/ai-cli/src/commands/video.ts
@@ -1,6 +1,11 @@
 import { experimental_generateVideo as generateVideo, gateway } from "ai";
 import type { Command } from "commander";
 
+import {
+  collectImageReference,
+  loadImageReferences,
+  type ImageReference,
+} from "../lib/image-references.js";
 import { buildJobs, runJobs } from "../lib/jobs.js";
 import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import {
@@ -16,6 +21,7 @@ const DEFAULT_TIMEOUT_MS = 300_000;
 interface VideoOptions {
   model?: string;
   output?: string;
+  image?: string[];
   count?: string;
   aspectRatio?: string;
   duration?: string;
@@ -35,6 +41,12 @@ export function registerVideoCommand(program: Command) {
       "Model ID (creator/model-name), comma-separated for multi-model"
     )
     .option("-o, --output <path>", "Output file path or directory")
+    .option(
+      "-i, --image <path-or-url>",
+      "Image input path or URL",
+      collectImageReference,
+      []
+    )
     .option("-n, --count <n>", "Number of videos per model (default: 1)")
     .option("--aspect-ratio <W:H>", "Aspect ratio (e.g. 16:9)")
     .option("--duration <seconds>", "Video duration in seconds")
@@ -51,18 +63,40 @@ export function registerVideoCommand(program: Command) {
     .action(async (rawPrompt: string | undefined, opts: VideoOptions) => {
       const prompt = rawPrompt?.trim() || undefined;
       const stdin = await readStdin();
-      if (!prompt && !stdin) {
+      const imageReferenceInputs = opts.image ?? [];
+      if (!prompt && !stdin && imageReferenceInputs.length === 0) {
         process.stderr.write(
-          "Error: prompt is required (provide as argument or pipe via stdin)\n"
+          "Error: prompt or image is required (provide a prompt, --image, or pipe an image via stdin)\n"
         );
         process.exit(1);
       }
 
-      let videoPrompt: string | { image: Uint8Array; text?: string } = prompt!;
-      if (stdin) {
+      let referenceImages: ImageReference[] = [];
+      try {
+        referenceImages = await loadImageReferences(imageReferenceInputs);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`Error: ${message}\n`);
+        process.exit(1);
+      }
+
+      const images: ImageReference[] = [
+        ...(stdin ? [new Uint8Array(stdin)] : []),
+        ...referenceImages,
+      ];
+      if (images.length > 1) {
+        process.stderr.write(
+          "Error: video generation accepts one input image; provide one --image value or pipe one image via stdin\n"
+        );
+        process.exit(1);
+      }
+
+      let videoPrompt: string | { image: ImageReference; text?: string } =
+        prompt!;
+      if (images.length > 0) {
         videoPrompt = prompt
-          ? { image: new Uint8Array(stdin), text: prompt }
-          : { image: new Uint8Array(stdin) };
+          ? { image: images[0]!, text: prompt }
+          : { image: images[0]! };
       }
 
       const gatewayModels = await fetchGatewayModels();


### PR DESCRIPTION
- Add -i/--image support to ai video using shared image reference loading
- Document direct image inputs and the single-image video constraint
- Cover video help output and image path validation in CLI tests