### PR TITLE
Improve default output filenames

### DIFF
--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -134,9 +134,11 @@ When running in a terminal that supports the [Kitty graphics protocol](https://s
 
 ### Output Behavior
 
-- **text**: saves to `output.md` (interactive), stdout when piped
-- **image/video**: saves to file (interactive), raw binary stdout when piped
+- **text**: saves to `<id>.md` (interactive), stdout when piped
+- **image/video**: saves to `<id>.png` / `<id>.mp4` (interactive), raw binary stdout when piped
 - **`-o <dir>`**: saves inside the directory with auto-generated names
+
+When the CLI needs to choose a filename, it uses a response id when available and falls back to a random 8-character id.
 
 ### Environment Variables
 

--- a/packages/ai-cli/src/commands/image.ts
+++ b/packages/ai-cli/src/commands/image.ts
@@ -9,6 +9,7 @@ import {
 import { buildJobs, runJobs } from "../lib/jobs.js";
 import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import { parsePositiveInt, parseSize, parseAspectRatio } from "../lib/parse.js";
+import { responseIdFromHeaders } from "../lib/response-id.js";
 import { readStdin } from "../lib/stdin.js";
 
 const DEFAULT_CONCURRENCY = 4;
@@ -166,7 +167,10 @@ export function registerImageCommand(program: Command) {
                 `Model ${modelId} did not return an image in the response`
               );
             }
-            return Buffer.from(imageFile.uint8Array);
+            return {
+              data: Buffer.from(imageFile.uint8Array),
+              id: result.response.id,
+            };
           }
 
           const result = await generateImage({
@@ -183,7 +187,10 @@ export function registerImageCommand(program: Command) {
             providerOptions:
               Object.keys(provOpts).length > 0 ? provOpts : undefined,
           });
-          return Buffer.from(result.image.uint8Array);
+          return {
+            data: Buffer.from(result.image.uint8Array),
+            id: responseIdFromHeaders(result.responses[0]?.headers),
+          };
         },
         {
           noun: "image",

--- a/packages/ai-cli/src/commands/text.ts
+++ b/packages/ai-cli/src/commands/text.ts
@@ -131,7 +131,7 @@ export function registerTextCommand(program: Command) {
             temperature,
             abortSignal: abort,
           });
-          return result.text;
+          return { data: result.text, id: result.response.id };
         },
         {
           noun: "text",

--- a/packages/ai-cli/src/commands/video.ts
+++ b/packages/ai-cli/src/commands/video.ts
@@ -13,6 +13,7 @@ import {
   parseAspectRatio,
   parseNonNegativeFloat,
 } from "../lib/parse.js";
+import { responseIdFromHeaders } from "../lib/response-id.js";
 import { readStdin } from "../lib/stdin.js";
 
 const DEFAULT_CONCURRENCY = 2;
@@ -128,7 +129,10 @@ export function registerVideoCommand(program: Command) {
             aspectRatio,
             duration,
           });
-          return Buffer.from(result.video.uint8Array);
+          return {
+            data: Buffer.from(result.video.uint8Array),
+            id: responseIdFromHeaders(result.responses[0]?.headers),
+          };
         },
         {
           noun: "video",

--- a/packages/ai-cli/src/lib/jobs.ts
+++ b/packages/ai-cli/src/lib/jobs.ts
@@ -40,9 +40,16 @@ export interface RunJobsResult {
   failed: number;
 }
 
+export interface GeneratedOutput {
+  data: Buffer | string;
+  id?: string;
+}
+
+type GenerateResult = Buffer | string | GeneratedOutput;
+
 export async function runJobs(
   jobs: Job[],
-  generate: (modelId: string) => Promise<Buffer | string>,
+  generate: (modelId: string) => Promise<GenerateResult>,
   opts: RunJobsOptions
 ): Promise<RunJobsResult> {
   const { noun, format, outputPath, quiet, json, concurrency, display } = opts;
@@ -54,15 +61,16 @@ export async function runJobs(
     progress.start(`Generating ${noun} with ${modelId}`);
 
     try {
-      const data = await generate(modelId);
+      const generated = normalizeGeneratedOutput(await generate(modelId));
       const elapsed = Date.now() - start;
       progress.stop(`Generated ${noun} with ${modelId}`);
 
       if (json) {
         const path = await writeOutput({
-          data,
+          data: generated.data,
           format,
           outputPath,
+          outputId: generated.id,
           quiet: true,
           display,
         });
@@ -81,7 +89,14 @@ export async function runJobs(
         };
         process.stdout.write(JSON.stringify(meta, null, 2) + "\n");
       } else {
-        await writeOutput({ data, format, outputPath, quiet, display });
+        await writeOutput({
+          data: generated.data,
+          format,
+          outputPath,
+          outputId: generated.id,
+          quiet,
+          display,
+        });
       }
     } catch (err) {
       progress.stop();
@@ -117,19 +132,20 @@ export async function runJobs(
       multi.startLine(lineIdxs[i]);
       const genStart = Date.now();
       try {
-        const data = await generate(job.modelId);
+        const generated = normalizeGeneratedOutput(await generate(job.modelId));
         const genElapsed = Date.now() - genStart;
         const suffix = `${i + 1}`;
         const path = await writeOutput({
-          data,
+          data: generated.data,
           format,
           outputPath,
+          outputId: generated.id,
           suffix,
           quiet: true,
           display: false,
         });
-        if (shouldDisplay && Buffer.isBuffer(data))
-          pendingDisplayBuffers.push(data);
+        if (shouldDisplay && Buffer.isBuffer(generated.data))
+          pendingDisplayBuffers.push(generated.data);
         const savedMsg = path
           ? `Saved to ${path}`
           : `${noun[0].toUpperCase()}${noun.slice(1)} ${job.label} written to stdout`;
@@ -189,4 +205,12 @@ export async function runJobs(
 
   const failCount = results.filter((r) => !r.success).length;
   return { total: results.length, failed: failCount };
+}
+
+function normalizeGeneratedOutput(result: GenerateResult): GeneratedOutput {
+  if (typeof result === "string" || Buffer.isBuffer(result)) {
+    return { data: result };
+  }
+
+  return result;
 }

--- a/packages/ai-cli/src/lib/output.test.ts
+++ b/packages/ai-cli/src/lib/output.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { basename, join } from "path";
+
+import { writeOutput } from "./output.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), "ai-cli-output-"));
+  try {
+    return await fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("writeOutput", () => {
+  test("uses output id when writing to a directory", async () => {
+    await withTempDir(async (dir) => {
+      const path = await writeOutput({
+        data: "hello",
+        format: "md",
+        outputPath: dir,
+        outputId: "resp_123",
+        quiet: true,
+      });
+
+      expect(path).not.toBeNull();
+      expect(basename(path!)).toBe("resp_123.md");
+      expect(readFileSync(path!, "utf8")).toBe("hello");
+    });
+  });
+
+  test("sanitizes output ids before using them as filenames", async () => {
+    await withTempDir(async (dir) => {
+      const path = await writeOutput({
+        data: Buffer.from([1, 2, 3]),
+        format: "image",
+        outputPath: dir,
+        outputId: "gateway/resp 123",
+        quiet: true,
+        display: false,
+      });
+
+      expect(path).not.toBeNull();
+      expect(basename(path!)).toBe("gateway-resp-123.png");
+      expect(existsSync(path!)).toBe(true);
+    });
+  });
+
+  test("uses random 8-character names without an output id", async () => {
+    await withTempDir(async (dir) => {
+      const path = await writeOutput({
+        data: "hello",
+        format: "txt",
+        outputPath: dir,
+        quiet: true,
+      });
+
+      expect(path).not.toBeNull();
+      expect(basename(path!)).toMatch(/^[0-9a-f]{8}\.txt$/);
+    });
+  });
+
+  test("keeps explicit output filenames", async () => {
+    await withTempDir(async (dir) => {
+      const explicitPath = join(dir, "custom.md");
+      const path = await writeOutput({
+        data: "hello",
+        format: "md",
+        outputPath: explicitPath,
+        outputId: "resp_123",
+        quiet: true,
+      });
+
+      expect(path).toBe(explicitPath);
+      expect(readFileSync(path!, "utf8")).toBe("hello");
+    });
+  });
+});

--- a/packages/ai-cli/src/lib/output.ts
+++ b/packages/ai-cli/src/lib/output.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "crypto";
 import { writeFileSync, mkdirSync, statSync } from "fs";
 import { resolve, join, dirname } from "path";
 
@@ -20,13 +21,28 @@ export interface WriteOutputOptions {
   data: Buffer | string;
   format: OutputFormat;
   outputPath?: string;
+  outputId?: string;
   suffix?: string;
   quiet?: boolean;
   display?: boolean;
 }
 
-function defaultFilename(format: OutputFormat): string {
-  return `output${DEFAULT_EXTENSIONS[format]}`;
+function defaultFilename(format: OutputFormat, outputId?: string): string {
+  return `${filenameStem(outputId)}${DEFAULT_EXTENSIONS[format]}`;
+}
+
+function filenameStem(outputId?: string): string {
+  return sanitizeFilenameStem(outputId) ?? randomBytes(4).toString("hex");
+}
+
+function sanitizeFilenameStem(outputId?: string): string | undefined {
+  const trimmed = outputId?.trim();
+  if (!trimmed) return undefined;
+
+  const sanitized = trimmed.replace(/[^A-Za-z0-9._-]+/g, "-");
+  if (!sanitized || sanitized === "." || sanitized === "..") return undefined;
+
+  return sanitized;
 }
 
 function isDirectory(p: string): boolean {
@@ -40,7 +56,7 @@ function isDirectory(p: string): boolean {
 export async function writeOutput(
   opts: WriteOutputOptions
 ): Promise<string | null> {
-  const { data, format, suffix, quiet, display } = opts;
+  const { data, format, outputId, suffix, quiet, display } = opts;
   const effectiveOutput = opts.outputPath ?? process.env.AI_CLI_OUTPUT_DIR;
   const buf = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
   const shouldDisplay =
@@ -54,7 +70,7 @@ export async function writeOutput(
     if (isDirectory(effectiveOutput)) {
       filePath = join(
         effectiveOutput,
-        addSuffix(defaultFilename(format), suffix)
+        addSuffix(defaultFilename(format, outputId), suffix)
       );
     } else {
       filePath = addSuffix(effectiveOutput, suffix);
@@ -72,7 +88,7 @@ export async function writeOutput(
     return null;
   }
 
-  const filename = addSuffix(defaultFilename(format), suffix);
+  const filename = addSuffix(defaultFilename(format, outputId), suffix);
   const path = resolve(filename);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, buf);

--- a/packages/ai-cli/src/lib/response-id.ts
+++ b/packages/ai-cli/src/lib/response-id.ts
@@ -1,0 +1,24 @@
+const RESPONSE_ID_HEADERS = [
+  "x-ai-gateway-response-id",
+  "x-ai-gateway-request-id",
+  "x-vercel-id",
+  "x-request-id",
+  "request-id",
+];
+
+export function responseIdFromHeaders(
+  headers?: Record<string, string>
+): string | undefined {
+  if (!headers) return undefined;
+
+  const normalized = new Map(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+
+  for (const header of RESPONSE_ID_HEADERS) {
+    const value = normalized.get(header)?.trim();
+    if (value) return value;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
- Use response ids/header ids for autogenerated output filenames, with random 8-character fallback.
- Thread output ids through text, image, and video job results while preserving explicit paths.
- Document output behavior and cover filename selection with focused tests.