### PR TITLE
fix (image): forward aspect ratio to Google language-image models

### DIFF
--- a/packages/ai-cli/src/commands/image.test.ts
+++ b/packages/ai-cli/src/commands/image.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildLanguageImageProviderOptions } from "./image.js";
+
+describe("buildLanguageImageProviderOptions", () => {
+  test("returns undefined for non-google creators", () => {
+    expect(buildLanguageImageProviderOptions("openai", "16:9")).toBeUndefined();
+    expect(
+      buildLanguageImageProviderOptions(undefined, "16:9")
+    ).toBeUndefined();
+  });
+
+  test("requests image+text modalities for google without an aspect ratio", () => {
+    expect(buildLanguageImageProviderOptions("google", undefined)).toEqual({
+      google: { responseModalities: ["IMAGE", "TEXT"] },
+    });
+  });
+
+  test("forwards the aspect ratio via imageConfig for google", () => {
+    expect(buildLanguageImageProviderOptions("google", "16:9")).toEqual({
+      google: {
+        responseModalities: ["IMAGE", "TEXT"],
+        imageConfig: { aspectRatio: "16:9" },
+      },
+    });
+  });
+});

--- a/packages/ai-cli/src/commands/image.ts
+++ b/packages/ai-cli/src/commands/image.ts
@@ -154,10 +154,10 @@ export function registerImageCommand(program: Command) {
               model: gateway(modelId),
               messages: [{ role: "user", content: messageContent }],
               abortSignal: abort,
-              providerOptions:
-                creator === "google"
-                  ? { google: { responseModalities: ["IMAGE", "TEXT"] } }
-                  : undefined,
+              providerOptions: buildLanguageImageProviderOptions(
+                creator,
+                aspectRatio
+              ),
             });
             const imageFile = result.files?.find((f) =>
               f.mediaType.startsWith("image/")
@@ -207,6 +207,38 @@ export function registerImageCommand(program: Command) {
       if (failed === total) process.exit(1);
       if (failed > 0) process.exit(2);
     });
+}
+
+/**
+ * Build provider options for the language-image (generateText) path.
+ *
+ * Google language-image models such as `gemini-2.5-flash-image` produce images
+ * through `generateText`, so the `aspectRatio` understood by `generateImage`
+ * never reaches them. Google does support it natively via
+ * `providerOptions.google.imageConfig.aspectRatio` (defaulting to 1:1 when
+ * unset), so we forward it here. Note that these models do not support `size`,
+ * so only the aspect ratio is passed through.
+ */
+export function buildLanguageImageProviderOptions(
+  creator: string | undefined,
+  aspectRatio: `${number}:${number}` | undefined
+):
+  | {
+      google: {
+        responseModalities: string[];
+        imageConfig?: { aspectRatio: `${number}:${number}` };
+      };
+    }
+  | undefined {
+  if (creator !== "google") return undefined;
+  const google: {
+    responseModalities: string[];
+    imageConfig?: { aspectRatio: `${number}:${number}` };
+  } = { responseModalities: ["IMAGE", "TEXT"] };
+  if (aspectRatio) {
+    google.imageConfig = { aspectRatio };
+  }
+  return { google };
 }
 
 function buildProviderOptions(


### PR DESCRIPTION
Closes #61.

## What

`--aspect-ratio` had no effect for language-image models such as `google/gemini-2.5-flash-image`. These models are generated through the `generateText` path, where the only provider options passed for Google were `{ google: { responseModalities: ["IMAGE", "TEXT"] } }`. `aspectRatio` was only forwarded on the `generateImage` path, so it was silently dropped — every output came back 1:1.

## Fix

Gemini image models support aspect ratio natively via `providerOptions.google.imageConfig.aspectRatio` (defaulting to `1:1` when unset). This forwards the `--aspect-ratio` flag through that field when a Google model goes through the `generateText` path.

- `--size` is intentionally **not** forwarded: Gemini image models don't support it (the AI SDK docs state "Gemini image models do not support the size or n parameters. Use aspectRatio instead").
- The provider-options construction is extracted into a pure `buildLanguageImageProviderOptions(creator, aspectRatio)` helper, covered by unit tests.

## Verification

- `bun run typecheck` — passes
- `bun test` — 86 pass / 0 fail (3 new tests for the helper)
- `oxlint` — 0 warnings / 0 errors

Refs:
- AI SDK docs (Google Generative AI): https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai