### PR TITLE
fix(image): Increase default timeout from 120s to 300s

### DIFF
--- a/packages/ai-cli/src/commands/image.ts
+++ b/packages/ai-cli/src/commands/image.ts
@@ -13,7 +13,7 @@ import { responseIdFromHeaders } from "../lib/response-id.js";
 import { readStdin } from "../lib/stdin.js";
 
 const DEFAULT_CONCURRENCY = 4;
-const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_TIMEOUT_MS = 300_000;
 
 interface ImageOptions {
   model?: string;


### PR DESCRIPTION
gpt-image-2 with quality set to `high` takes more than 2 minutes per generation. Timeout should be at least 5 minutes.

Fixes #63 