### PR TITLE
feat: support custom OpenAI-compatible base URL

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,11 +36,12 @@
     },
     "packages/ai-cli": {
       "name": "ai-cli",
-      "version": "0.1.0",
+      "version": "0.3.1",
       "bin": {
-        "ai": "./src/index.ts",
+        "ai": "./dist/index.js",
       },
       "dependencies": {
+        "@ai-sdk/openai-compatible": "2.0.52",
         "ai": "^6.0.173",
         "commander": "^14.0.3",
       },
@@ -63,9 +64,11 @@
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.108", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hOtwiM6E/m1PgqHnx0/grvh0P/kjENHsN222OL5iYPQwfWmcX+26oFXM7HGL/UzonB+RORMkYAbskgAiANVwCQ=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+    "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.52", "", { "dependencies": { "@ai-sdk/provider": "3.0.11", "@ai-sdk/provider-utils": "4.0.31" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-WdVesd9VJQv8BLLla+x1AjLa40D3QUfnXH488+ydOcOIX7c4m6RF8Sh3JsAF+5ICa2Vknc9GTBlOvqCKoivE1w=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.11", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-GKu3RxsfKGWjBiXmEdsKsGR9uVgJ56mzL1w7mLsn5k2TiNtpyS2IYQo3v1NJpK3oyv2OVavlK3g801VSe+gujg=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.31", "", { "dependencies": { "@ai-sdk/provider": "3.0.11", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-x4Q1NxNLw8V1AHKOunukpksbKCqzZdZEgpHgbZznUE3ZcWb2liI5j2321TlOvyfn1iL7NmNMFTD5mZYoChVx0g=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -771,6 +774,10 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
@@ -782,6 +789,10 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
 
     "ai-cli/oxfmt": ["oxfmt@0.47.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.47.0", "@oxfmt/binding-android-arm64": "0.47.0", "@oxfmt/binding-darwin-arm64": "0.47.0", "@oxfmt/binding-darwin-x64": "0.47.0", "@oxfmt/binding-freebsd-x64": "0.47.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.47.0", "@oxfmt/binding-linux-arm-musleabihf": "0.47.0", "@oxfmt/binding-linux-arm64-gnu": "0.47.0", "@oxfmt/binding-linux-arm64-musl": "0.47.0", "@oxfmt/binding-linux-ppc64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-musl": "0.47.0", "@oxfmt/binding-linux-s390x-gnu": "0.47.0", "@oxfmt/binding-linux-x64-gnu": "0.47.0", "@oxfmt/binding-linux-x64-musl": "0.47.0", "@oxfmt/binding-openharmony-arm64": "0.47.0", "@oxfmt/binding-win32-arm64-msvc": "0.47.0", "@oxfmt/binding-win32-ia32-msvc": "0.47.0", "@oxfmt/binding-win32-x64-msvc": "0.47.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA=="],
 

--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -146,6 +146,7 @@ When the CLI needs to choose a filename, it uses a response id when available an
 |---|---|
 | `AI_GATEWAY_API_KEY` | AI Gateway authentication key |
 | `OPENAI_API_KEY` | Provider-specific key (or other provider keys) |
+| `OPENAI_BASE_URL` | Route `text` and `image` to a custom OpenAI-compatible endpoint instead of the AI Gateway (see below) |
 | `AI_CLI_TEXT_MODEL` | Default text model (overrides `openai/gpt-5.5`) |
 | `AI_CLI_IMAGE_MODEL` | Default image model (overrides `openai/gpt-image-2`) |
 | `AI_CLI_VIDEO_MODEL` | Default video model (overrides `bytedance/seedance-2.0`) |
@@ -155,6 +156,25 @@ When the CLI needs to choose a filename, it uses a response id when available an
 | `FORCE_COLOR` | Force color output even when not a TTY |
 
 The `-m` flag always takes priority over `AI_CLI_*_MODEL` env vars. The `-o` flag always takes priority over `AI_CLI_OUTPUT_DIR`.
+
+### Custom OpenAI-compatible endpoint
+
+Set `OPENAI_BASE_URL` to point `text` and `image` generation at any OpenAI-compatible server (vLLM, Ollama, LM Studio, LocalAI, OpenRouter, a self-hosted gateway, etc.) instead of the Vercel AI Gateway. `OPENAI_API_KEY` is used for authentication.
+
+```sh
+export OPENAI_BASE_URL="https://my-host/v1"
+export OPENAI_API_KEY="sk-..."
+
+ai text -m llama-3.3-70b "hello"
+ai image -m my-image-model "a sunset"
+```
+
+Notes:
+
+- Text is sent to the endpoint's `/chat/completions`, images to `/v1/images/generations`.
+- `ai models` lists whatever the endpoint's `/models` returns. Since that response carries no type metadata, every model is shown under both Text and Image — pass an explicit `-m <id>` for the one you want.
+- Set `AI_CLI_TEXT_MODEL` / `AI_CLI_IMAGE_MODEL` if you want defaults other than the gateway ones (`openai/gpt-5.5`, `openai/gpt-image-2`), which likely won't exist on your endpoint.
+- `video` has no OpenAI-compatible standard and always uses the AI Gateway.
 
 ### Timeouts
 

--- a/packages/ai-cli/package.json
+++ b/packages/ai-cli/package.json
@@ -40,6 +40,7 @@
     "prepack": "bun run typecheck && bun run build"
   },
   "dependencies": {
+    "@ai-sdk/openai-compatible": "2.0.52",
     "ai": "^6.0.173",
     "commander": "^14.0.3"
   },

--- a/packages/ai-cli/src/commands/image.ts
+++ b/packages/ai-cli/src/commands/image.ts
@@ -1,4 +1,4 @@
-import { generateImage, generateText, gateway } from "ai";
+import { generateImage, generateText } from "ai";
 import type { Command } from "commander";
 
 import {
@@ -9,6 +9,7 @@ import {
 import { buildJobs, runJobs } from "../lib/jobs.js";
 import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import { parsePositiveInt, parseSize, parseAspectRatio } from "../lib/parse.js";
+import { imageModel, languageModel } from "../lib/provider.js";
 import { responseIdFromHeaders } from "../lib/response-id.js";
 import { readStdin } from "../lib/stdin.js";
 
@@ -151,7 +152,7 @@ export function registerImageCommand(program: Command) {
                 "http-referer": "https://github.com/vercel-labs/ai-cli",
                 "x-title": "ai-cli",
               },
-              model: gateway(modelId),
+              model: languageModel(modelId),
               messages: [{ role: "user", content: messageContent }],
               abortSignal: abort,
               providerOptions:
@@ -178,7 +179,7 @@ export function registerImageCommand(program: Command) {
               "http-referer": "https://github.com/vercel-labs/ai-cli",
               "x-title": "ai-cli",
             },
-            model: gateway.image(modelId),
+            model: imageModel(modelId),
             prompt: imagePrompt,
             abortSignal: abort,
             n: 1,

--- a/packages/ai-cli/src/commands/text.ts
+++ b/packages/ai-cli/src/commands/text.ts
@@ -1,6 +1,5 @@
 import {
   generateText,
-  gateway,
   type ImagePart,
   type ModelMessage,
   type TextPart,
@@ -17,6 +16,7 @@ import { buildJobs, runJobs } from "../lib/jobs.js";
 import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import type { OutputFormat } from "../lib/output.js";
 import { parsePositiveInt, parseTemperature } from "../lib/parse.js";
+import { languageModel } from "../lib/provider.js";
 import { readStdin, stdinAsText } from "../lib/stdin.js";
 
 const DEFAULT_CONCURRENCY = 4;
@@ -124,7 +124,7 @@ export function registerTextCommand(program: Command) {
               "http-referer": "https://github.com/vercel-labs/ai-cli",
               "x-title": "ai-cli",
             },
-            model: gateway(modelId),
+            model: languageModel(modelId),
             prompt: textPrompt,
             system: opts.system,
             maxOutputTokens: maxTokens,

--- a/packages/ai-cli/src/lib/models.ts
+++ b/packages/ai-cli/src/lib/models.ts
@@ -1,3 +1,5 @@
+import { getCustomEndpoint, type CustomEndpoint } from "./provider.js";
+
 export type Modality = "text" | "image" | "video";
 
 const DEFAULTS: Record<Modality, string> = {
@@ -71,6 +73,9 @@ async function doFetch(): Promise<GatewayModels> {
     languageImageModelIds: new Set(),
   };
 
+  const custom = getCustomEndpoint();
+  if (custom) return doFetchCustom(custom, result);
+
   try {
     const res = await fetch(GATEWAY_MODELS_URL, {
       signal: AbortSignal.timeout(GATEWAY_TIMEOUT_MS),
@@ -138,6 +143,47 @@ async function doFetch(): Promise<GatewayModels> {
   } catch {
     cached = null;
     process.stderr.write("Warning: could not fetch models from AI Gateway\n");
+  }
+
+  return result;
+}
+
+/**
+ * Fetch the model list from an OpenAI-compatible `/models` endpoint. That
+ * response has no type/tag metadata, so every model is listed under both text
+ * and image; pass an explicit `-m <id>` for whichever you need.
+ */
+async function doFetchCustom(
+  endpoint: CustomEndpoint,
+  result: GatewayModels
+): Promise<GatewayModels> {
+  const url = `${endpoint.baseURL.replace(/\/+$/, "")}/models`;
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(GATEWAY_TIMEOUT_MS),
+      headers: endpoint.apiKey
+        ? { Authorization: `Bearer ${endpoint.apiKey}` }
+        : undefined,
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const json = (await res.json()) as { data?: RawGatewayModel[] };
+    const models = json.data ?? [];
+
+    for (const m of models) {
+      const entry: ModelEntry = {
+        id: m.id,
+        name: m.name,
+        description: m.description,
+        creator: m.owned_by ?? "other",
+        capabilities: ["text", "image"],
+      };
+      result.all.push(entry);
+      result.text.push(entry);
+      result.image.push(entry);
+    }
+  } catch {
+    cached = null;
+    process.stderr.write(`Warning: could not fetch models from ${url}\n`);
   }
 
   return result;

--- a/packages/ai-cli/src/lib/provider.ts
+++ b/packages/ai-cli/src/lib/provider.ts
@@ -1,0 +1,43 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { gateway, type ImageModel, type LanguageModel } from "ai";
+
+export interface CustomEndpoint {
+  baseURL: string;
+  apiKey?: string;
+}
+
+/**
+ * Read an OpenAI-compatible custom endpoint from the environment.
+ *
+ * Setting `OPENAI_BASE_URL` opts text and image generation out of the Vercel
+ * AI Gateway and routes them to the given endpoint instead (using
+ * `OPENAI_API_KEY` for auth). Video has no OpenAI-compatible standard and
+ * always stays on the gateway.
+ */
+export function getCustomEndpoint(): CustomEndpoint | null {
+  const baseURL = process.env.OPENAI_BASE_URL?.trim();
+  if (!baseURL) return null;
+  return { baseURL, apiKey: process.env.OPENAI_API_KEY };
+}
+
+function createCompat(endpoint: CustomEndpoint) {
+  return createOpenAICompatible({
+    name: "openai-compatible",
+    baseURL: endpoint.baseURL,
+    apiKey: endpoint.apiKey,
+  });
+}
+
+export function languageModel(modelId: string): LanguageModel {
+  const endpoint = getCustomEndpoint();
+  return endpoint
+    ? createCompat(endpoint).chatModel(modelId)
+    : gateway(modelId);
+}
+
+export function imageModel(modelId: string): ImageModel {
+  const endpoint = getCustomEndpoint();
+  return endpoint
+    ? createCompat(endpoint).imageModel(modelId)
+    : gateway.image(modelId);
+}


### PR DESCRIPTION
Set OPENAI_BASE_URL to route `text` and `image` generation to any OpenAI-compatible endpoint (vLLM, Ollama, LM Studio, OpenRouter, a self-hosted gateway, etc.) instead of the Vercel AI Gateway, using OPENAI_API_KEY for auth.

- add src/lib/provider.ts to route languageModel/imageModel to either createOpenAICompatible (when OPENAI_BASE_URL is set) or the gateway
- fetch the model list from the endpoint's /models when configured
- text.ts/image.ts now resolve models through the provider helpers
- video stays on the gateway (no OpenAI-compatible video standard)
- document OPENAI_BASE_URL in the README