### PR TITLE
feat: add audio speak and transcribe commands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,12 +36,13 @@
     },
     "packages/ai-cli": {
       "name": "ai-cli",
-      "version": "0.1.0",
+      "version": "0.3.1",
       "bin": {
-        "ai": "./src/index.ts",
+        "ai": "./dist/index.js",
       },
       "dependencies": {
-        "ai": "^6.0.173",
+        "@ai-sdk/gateway": "4.0.3",
+        "ai": "7.0.3",
         "commander": "^14.0.3",
       },
       "devDependencies": {
@@ -61,11 +62,11 @@
 
     "@ai-cli/web": ["@ai-cli/web@workspace:apps/web"],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.108", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hOtwiM6E/m1PgqHnx0/grvh0P/kjENHsN222OL5iYPQwfWmcX+26oFXM7HGL/UzonB+RORMkYAbskgAiANVwCQ=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.3", "", { "dependencies": { "@ai-sdk/provider": "4.0.0", "@ai-sdk/provider-utils": "5.0.0", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-V8p0skqA9I5ZvZ4JDrvdh+TrZ0OVvkoP4CPEMxy777yBcVO5febhtLUJ+t0V0ROvSIkWIm5R9nvyOsyZRtO9sQ=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.0", "", { "dependencies": { "@ai-sdk/provider": "4.0.0", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -341,11 +342,13 @@
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
+    "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "ai": ["ai@6.0.173", "", { "dependencies": { "@ai-sdk/gateway": "3.0.108", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-X2noFb82kouYQ4nlKGm1cR1Wvlp4Xit7fjJzwXv/msKQmtqkQn9NiXH6kCX4Gl4G+9DRWsJHIKANtWk8Ix1nTw=="],
+    "ai": ["ai@7.0.3", "", { "dependencies": { "@ai-sdk/gateway": "4.0.3", "@ai-sdk/provider": "4.0.0", "@ai-sdk/provider-utils": "5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ze2nTtoNW1hYhkjAVUVoLQGC/vDmNv+nIo3n8aCv2QQS8WCuC8o3CF6ywnUlui/i7lfGU4V8aPClVRH62WUHeA=="],
 
     "ai-cli": ["ai-cli@workspace:packages/ai-cli"],
 

--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -1,6 +1,6 @@
 # ai
 
-A tiny, agent-native CLI for generating images, video and text with dead-simple commands, stdin support and predictable artifact outputs. Uses [Vercel AI SDK](https://sdk.vercel.ai) and [AI Gateway](https://vercel.com/docs/ai-gateway) for unified access to hundreds of models.
+A tiny, agent-native CLI for generating images, video, audio and text with dead-simple commands, stdin support and predictable artifact outputs. Uses [Vercel AI SDK](https://sdk.vercel.ai) and [AI Gateway](https://vercel.com/docs/ai-gateway) for unified access to hundreds of models.
 
 ## Install
 
@@ -8,7 +8,7 @@ A tiny, agent-native CLI for generating images, video and text with dead-simple 
 npm install -g ai-cli
 ```
 
-Requires Node.js 20+ and an [AI Gateway](https://vercel.com/docs/ai-gateway) API key or a provider-specific key (e.g. `OPENAI_API_KEY`).
+Requires Node.js 22+ and an [AI Gateway](https://vercel.com/docs/ai-gateway) API key or a provider-specific key (e.g. `OPENAI_API_KEY`).
 
 ## Usage
 
@@ -16,6 +16,8 @@ Requires Node.js 20+ and an [AI Gateway](https://vercel.com/docs/ai-gateway) API
 ai image "a cute dog"
 ai video "a spinning triangle"
 ai text "explain quantum computing"
+ai audio speak "Thanks for trying ai-cli"
+ai audio transcribe recording.mp3
 ai models                          # list available models
 ```
 
@@ -30,6 +32,8 @@ ai text --image screenshot.png "what is broken in this UI?"
 cat photo.png | ai text "describe this image"
 cat notes.txt | ai text "summarize this"
 git diff | ai text "explain these changes"
+echo "Ship the changelog" | ai audio speak -o changelog.mp3
+cat recording.mp3 | ai audio transcribe
 ```
 
 ### Common Options
@@ -50,6 +54,7 @@ Model IDs can be specified as `creator/model-name` or just `model-name` (resolve
 ```bash
 ai text -m gpt-5.5 "hello"          # resolves to openai/gpt-5.5
 ai image -m flux-2-pro "a sunset"   # resolves to bfl/flux-2-pro
+ai audio speak -m tts-1 "hello"     # resolves to openai/tts-1
 ```
 
 ### image
@@ -104,15 +109,57 @@ ai text -i chart.png -i table.jpg "summarize the data"
 cat screenshot.png | ai text "list the visible errors"
 ```
 
+### audio
+
+`audio` has two subcommands:
+
+```bash
+ai audio speak "Hello from AI Gateway"
+ai audio transcribe recording.mp3
+```
+
+#### audio speak
+
+```
+-f, --format <fmt>       Audio output format (default: mp3)
+--voice <voice>          Voice to use for speech generation
+--instructions <text>    Instructions for speech generation
+--speed <n>              Speech speed
+--language <code>        Language code (e.g. en, fr) or auto
+```
+
+`audio speak` accepts text from an argument or stdin and saves audio to `<id>.mp3` by default:
+
+```bash
+ai audio speak --voice alloy "Read this as a friendly update"
+cat announcement.txt | ai audio speak --format wav -o announcement.wav
+```
+
+When using OpenAI speech models, `ai audio speak` defaults to the `alloy` voice unless `--voice` is provided.
+
+#### audio transcribe
+
+```
+-f, --format <fmt>       Output format: md, txt (default: txt)
+```
+
+`audio transcribe` accepts a local path, `file://` URL, `http(s)://` URL or piped audio:
+
+```bash
+ai audio transcribe meeting.mp3
+ai audio transcribe https://example.com/call.wav
+cat voice-note.mp3 | ai audio transcribe -o transcript.txt
+```
+
 ### models
 
 ```
---type <type>            Filter by type: text, image, video
+--type <type>            Filter by type: text, image, video, audio, speech, transcription
 --creator <name>         Filter by creator (e.g. openai, google)
 --json                   Output as JSON (includes descriptions)
 ```
 
-All model types (text, image, video) are fetched live from the AI Gateway.
+All model types (text, image, video, speech, transcription) are fetched live from the AI Gateway.
 
 ### Multi-Model Comparison
 
@@ -136,6 +183,8 @@ When running in a terminal that supports the [Kitty graphics protocol](https://s
 
 - **text**: saves to `<id>.md` (interactive), stdout when piped
 - **image/video**: saves to `<id>.png` / `<id>.mp4` (interactive), raw binary stdout when piped
+- **audio speak**: saves to `<id>.mp3` (interactive), raw binary stdout when piped
+- **audio transcribe**: saves to `<id>.txt` (interactive), stdout when piped
 - **`-o <dir>`**: saves inside the directory with auto-generated names
 
 When the CLI needs to choose a filename, it uses a response id when available and falls back to a random 8-character id.
@@ -149,6 +198,8 @@ When the CLI needs to choose a filename, it uses a response id when available an
 | `AI_CLI_TEXT_MODEL` | Default text model (overrides `openai/gpt-5.5`) |
 | `AI_CLI_IMAGE_MODEL` | Default image model (overrides `openai/gpt-image-2`) |
 | `AI_CLI_VIDEO_MODEL` | Default video model (overrides `bytedance/seedance-2.0`) |
+| `AI_CLI_SPEECH_MODEL` | Default speech model (overrides `openai/tts-1`) |
+| `AI_CLI_TRANSCRIPTION_MODEL` | Default transcription model (overrides `openai/whisper-1`) |
 | `AI_CLI_OUTPUT_DIR` | Default output directory for generated files |
 | `AI_CLI_PREVIEW` | Set to `1` to force inline image preview, `0` to disable |
 | `NO_COLOR` | Disable ANSI color output |
@@ -165,6 +216,8 @@ Requests that exceed the timeout are aborted automatically:
 | `text` | 120 seconds |
 | `image` | 120 seconds |
 | `video` | 300 seconds |
+| `audio speak` | 120 seconds |
+| `audio transcribe` | 120 seconds |
 
 ### Exit Codes
 

--- a/packages/ai-cli/package.json
+++ b/packages/ai-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-cli",
   "version": "0.3.1",
-  "description": "A tiny, agent-native CLI for generating images, video and text with dead-simple commands, stdin support and predictable artifact outputs",
+  "description": "A tiny, agent-native CLI for generating images, video, audio and text with dead-simple commands, stdin support and predictable artifact outputs",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {
@@ -9,7 +9,7 @@
     "url": "https://github.com/vercel-labs/ai-cli.git"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "bin": {
     "ai": "./dist/index.js"
@@ -24,6 +24,9 @@
     "generative",
     "image",
     "video",
+    "audio",
+    "speech",
+    "transcription",
     "text",
     "ai-sdk",
     "vercel"
@@ -40,7 +43,8 @@
     "prepack": "bun run typecheck && bun run build"
   },
   "dependencies": {
-    "ai": "^6.0.173",
+    "@ai-sdk/gateway": "4.0.3",
+    "ai": "7.0.3",
     "commander": "^14.0.3"
   },
   "devDependencies": {

--- a/packages/ai-cli/src/cli.test.ts
+++ b/packages/ai-cli/src/cli.test.ts
@@ -30,7 +30,7 @@ describe("cli integration", () => {
   test("--help exits 0 and lists subcommands", async () => {
     const { exitCode, stdout } = await run("--help");
     expect(exitCode).toBe(0);
-    for (const sub of ["text", "image", "video", "models"]) {
+    for (const sub of ["text", "image", "video", "audio", "models"]) {
       expect(stdout).toContain(sub);
     }
   });
@@ -73,6 +73,41 @@ describe("cli integration", () => {
     expect(stdout).toContain("--aspect-ratio");
   });
 
+  test("audio --help exits 0 and lists subcommands", async () => {
+    const { exitCode, stdout } = await run("audio", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("speak");
+    expect(stdout).toContain("transcribe");
+  });
+
+  test("audio speak --help exits 0 and lists flags", async () => {
+    const { exitCode, stdout } = await run("audio", "speak", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--voice");
+    expect(stdout).toContain("--format");
+    expect(stdout).toContain("--speed");
+  });
+
+  test("audio transcribe --help exits 0 and lists flags", async () => {
+    const { exitCode, stdout } = await run("audio", "transcribe", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--model");
+    expect(stdout).toContain("--format");
+    expect(stdout).toContain("--output");
+  });
+
+  test("audio speak with no text and no stdin exits 1", async () => {
+    const { exitCode, stderr } = await run("audio", "speak");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("text or stdin is required");
+  });
+
+  test("audio transcribe with no audio and no stdin exits 1", async () => {
+    const { exitCode, stderr } = await run("audio", "transcribe");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("audio file, URL, or stdin is required");
+  });
+
   test("video -i validates image paths before generation", async () => {
     const { exitCode, stderr } = await run(
       "video",
@@ -87,7 +122,7 @@ describe("cli integration", () => {
   });
 
   test("models --type invalid exits 1", async () => {
-    const { exitCode, stderr } = await run("models", "--type", "audio");
+    const { exitCode, stderr } = await run("models", "--type", "realtime");
     expect(exitCode).toBe(1);
     expect(stderr).toContain("must be one of");
   });

--- a/packages/ai-cli/src/commands/audio.ts
+++ b/packages/ai-cli/src/commands/audio.ts
@@ -1,0 +1,279 @@
+import { readFile } from "fs/promises";
+import { fileURLToPath } from "url";
+
+import { gateway } from "@ai-sdk/gateway";
+import { generateSpeech, transcribe } from "ai";
+import type { Command } from "commander";
+
+import { buildJobs, runJobs } from "../lib/jobs.js";
+import { fetchGatewayModels, resolveModels } from "../lib/models.js";
+import type { OutputFormat } from "../lib/output.js";
+import { parseNonNegativeFloat, parsePositiveInt } from "../lib/parse.js";
+import { responseIdFromHeaders } from "../lib/response-id.js";
+import { readStdin, stdinAsText } from "../lib/stdin.js";
+
+const DEFAULT_CONCURRENCY = 4;
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+interface SpeakOptions {
+  model?: string;
+  output?: string;
+  format?: string;
+  voice?: string;
+  instructions?: string;
+  speed?: string;
+  language?: string;
+  count?: string;
+  concurrency?: string;
+  quiet?: boolean;
+  json?: boolean;
+}
+
+interface TranscribeOptions {
+  model?: string;
+  output?: string;
+  format?: string;
+  count?: string;
+  concurrency?: string;
+  quiet?: boolean;
+  json?: boolean;
+}
+
+export function registerAudioCommand(program: Command) {
+  const audio = program
+    .command("audio")
+    .description("Generate speech or transcribe audio");
+
+  audio
+    .command("speak")
+    .description("Generate speech audio from text")
+    .argument("[text]", "Text to convert to speech")
+    .option(
+      "-m, --model <model>",
+      "Speech model ID (creator/model-name), comma-separated for multi-model"
+    )
+    .option("-o, --output <path>", "Output file path or directory")
+    .option("-f, --format <fmt>", "Audio output format (default: mp3)")
+    .option("--voice <voice>", "Voice to use for speech generation")
+    .option("--instructions <text>", "Instructions for speech generation")
+    .option("--speed <n>", "Speech speed")
+    .option("--language <code>", "Language code (e.g. en, fr) or auto")
+    .option("-n, --count <n>", "Number of generations per model (default: 1)")
+    .option(
+      "-p, --concurrency <n>",
+      `Max parallel generations (default: ${DEFAULT_CONCURRENCY})`
+    )
+    .option("-q, --quiet", "Suppress progress output")
+    .option("--json", "Output metadata as JSON")
+    .action(async (rawText: string | undefined, opts: SpeakOptions) => {
+      const text = rawText?.trim() || undefined;
+      const stdin = await readStdin();
+      const stdinText = stdin ? stdinAsText(stdin).trim() : undefined;
+      const speechText = buildSpeechText(text, stdinText);
+
+      if (!speechText) {
+        process.stderr.write(
+          "Error: text or stdin is required (provide text or pipe text via stdin)\n"
+        );
+        process.exit(1);
+      }
+
+      const outputFormat = resolveAudioFormat(opts.format);
+      const speed = opts.speed
+        ? parseNonNegativeFloat(opts.speed, "speed")
+        : undefined;
+      const gatewayModels = await fetchGatewayModels();
+      const models = resolveModels("speech", opts.model, gatewayModels.speech);
+      const countPerModel = opts.count
+        ? parsePositiveInt(opts.count, "count")
+        : 1;
+      const jobs = buildJobs(models, countPerModel);
+
+      const { total, failed } = await runJobs(
+        jobs,
+        async (modelId) => {
+          const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+          const result = await generateSpeech({
+            headers: gatewayHeaders(),
+            model: gateway.speechModel(modelId),
+            text: speechText,
+            voice: opts.voice ?? defaultVoiceForModel(modelId),
+            outputFormat,
+            instructions: opts.instructions,
+            speed,
+            language: opts.language,
+            abortSignal: abort,
+          });
+          return {
+            data: Buffer.from(result.audio.uint8Array),
+            id: responseIdFromHeaders(result.responses[0]?.headers),
+          };
+        },
+        {
+          noun: "audio",
+          format: "audio",
+          extension: extensionForAudioFormat(outputFormat),
+          outputPath: opts.output,
+          quiet: opts.quiet,
+          json: opts.json,
+          concurrency: opts.concurrency
+            ? parsePositiveInt(opts.concurrency, "concurrency")
+            : DEFAULT_CONCURRENCY,
+        }
+      );
+      if (failed === total) process.exit(1);
+      if (failed > 0) process.exit(2);
+    });
+
+  audio
+    .command("transcribe")
+    .description("Transcribe audio to text")
+    .argument("[audio]", "Audio file path or URL")
+    .option(
+      "-m, --model <model>",
+      "Transcription model ID (creator/model-name), comma-separated for multi-model"
+    )
+    .option("-o, --output <path>", "Output file path or directory")
+    .option("-f, --format <fmt>", "Output format: md, txt (default: txt)")
+    .option(
+      "-n, --count <n>",
+      "Number of transcriptions per model (default: 1)"
+    )
+    .option(
+      "-p, --concurrency <n>",
+      `Max parallel transcriptions (default: ${DEFAULT_CONCURRENCY})`
+    )
+    .option("-q, --quiet", "Suppress progress output")
+    .option("--json", "Output metadata as JSON")
+    .action(async (rawAudio: string | undefined, opts: TranscribeOptions) => {
+      const stdin = await readStdin();
+      if (!rawAudio && !stdin) {
+        process.stderr.write(
+          "Error: audio file, URL, or stdin is required (provide an audio path/URL or pipe audio via stdin)\n"
+        );
+        process.exit(1);
+      }
+
+      let audioInput: Uint8Array | URL;
+      try {
+        audioInput = await loadAudioInput(rawAudio, stdin);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`Error: ${message}\n`);
+        process.exit(1);
+      }
+
+      const format = resolveTranscriptFormat(opts.format);
+      const gatewayModels = await fetchGatewayModels();
+      const models = resolveModels(
+        "transcription",
+        opts.model,
+        gatewayModels.transcription
+      );
+      const countPerModel = opts.count
+        ? parsePositiveInt(opts.count, "count")
+        : 1;
+      const jobs = buildJobs(models, countPerModel);
+
+      const { total, failed } = await runJobs(
+        jobs,
+        async (modelId) => {
+          const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+          const result = await transcribe({
+            headers: gatewayHeaders(),
+            model: gateway.transcriptionModel(modelId),
+            audio: audioInput,
+            abortSignal: abort,
+          });
+          return {
+            data: result.text,
+            id: responseIdFromHeaders(result.responses[0]?.headers),
+          };
+        },
+        {
+          noun: "transcript",
+          format,
+          outputPath: opts.output,
+          quiet: opts.quiet,
+          json: opts.json,
+          concurrency: opts.concurrency
+            ? parsePositiveInt(opts.concurrency, "concurrency")
+            : DEFAULT_CONCURRENCY,
+        }
+      );
+      if (failed === total) process.exit(1);
+      if (failed > 0) process.exit(2);
+    });
+}
+
+function buildSpeechText(
+  text?: string,
+  stdinText?: string
+): string | undefined {
+  if (stdinText && text) return `${stdinText}\n\n${text}`;
+  return stdinText || text;
+}
+
+function resolveAudioFormat(format?: string): string {
+  if (!format) return "mp3";
+
+  const normalized = format.trim().toLowerCase();
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(normalized)) {
+    throw new Error(
+      `--format must be a valid audio format name (got "${format}")`
+    );
+  }
+
+  return normalized;
+}
+
+function extensionForAudioFormat(format: string): string {
+  return `.${format}`;
+}
+
+function resolveTranscriptFormat(format?: string): OutputFormat {
+  if (!format || format === "txt") return "txt";
+  if (format === "md") return "md";
+  throw new Error(`--format must be one of: md, txt (got "${format}")`);
+}
+
+async function loadAudioInput(
+  rawAudio: string | undefined,
+  stdin: Buffer | null
+): Promise<Uint8Array | URL> {
+  if (stdin) return new Uint8Array(stdin);
+  const audio = rawAudio?.trim();
+  if (!audio) throw new Error("audio file, URL, or stdin is required");
+
+  const url = parseUrl(audio);
+  if (url?.protocol === "http:" || url?.protocol === "https:") return url;
+  if (url?.protocol === "file:")
+    return new Uint8Array(await readFile(fileURLToPath(url)));
+  if (url) throw new Error(`unsupported audio URL protocol "${url.protocol}"`);
+
+  try {
+    return new Uint8Array(await readFile(audio));
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`could not read audio file "${audio}": ${reason}`);
+  }
+}
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function defaultVoiceForModel(modelId: string): string | undefined {
+  return modelId.startsWith("openai/") ? "alloy" : undefined;
+}
+
+function gatewayHeaders(): Record<string, string> {
+  return {
+    "http-referer": "https://github.com/vercel-labs/ai-cli",
+    "x-title": "ai-cli",
+  };
+}

--- a/packages/ai-cli/src/commands/models.ts
+++ b/packages/ai-cli/src/commands/models.ts
@@ -6,6 +6,8 @@ import {
   type ModelEntry,
 } from "../lib/models.js";
 
+type ModelFilter = Modality | "audio";
+
 function groupByCreator(models: ModelEntry[]): Map<string, ModelEntry[]> {
   const groups = new Map<string, ModelEntry[]>();
   for (const m of models) {
@@ -26,13 +28,23 @@ export function registerModelsCommand(program: Command) {
   program
     .command("models")
     .description("List available models from AI Gateway")
-    .option("--type <type>", "Filter by type: text, image, video")
+    .option(
+      "--type <type>",
+      "Filter by type: text, image, video, audio, speech, transcription"
+    )
     .option("--creator <name>", "Filter by creator (e.g. openai, google)")
     .option("--json", "Output as JSON (includes descriptions)")
     .action(
       async (opts: { type?: string; creator?: string; json?: boolean }) => {
-        const validTypes = ["text", "image", "video"];
-        const filterType = opts.type?.toLowerCase() as Modality | undefined;
+        const validTypes = [
+          "text",
+          "image",
+          "video",
+          "audio",
+          "speech",
+          "transcription",
+        ];
+        const filterType = opts.type?.toLowerCase() as ModelFilter | undefined;
         if (filterType && !validTypes.includes(filterType)) {
           process.stderr.write(
             `Error: --type must be one of: ${validTypes.join(", ")} (got "${opts.type}")\n`
@@ -47,7 +59,10 @@ export function registerModelsCommand(program: Command) {
           let entries = gatewayModels.all;
           if (filterType) {
             entries = entries.filter((m) =>
-              m.capabilities.includes(filterType)
+              filterType === "audio"
+                ? m.capabilities.includes("speech") ||
+                  m.capabilities.includes("transcription")
+                : m.capabilities.includes(filterType)
             );
           }
           if (filterCreator) {
@@ -74,6 +89,17 @@ export function registerModelsCommand(program: Command) {
           sections.push({ title: "Image", entries: gatewayModels.image });
         if (!filterType || filterType === "video")
           sections.push({ title: "Video", entries: gatewayModels.video });
+        if (!filterType || filterType === "audio" || filterType === "speech")
+          sections.push({ title: "Speech", entries: gatewayModels.speech });
+        if (
+          !filterType ||
+          filterType === "audio" ||
+          filterType === "transcription"
+        )
+          sections.push({
+            title: "Transcription",
+            entries: gatewayModels.transcription,
+          });
 
         let totalCount = 0;
         for (const section of sections) {

--- a/packages/ai-cli/src/index.ts
+++ b/packages/ai-cli/src/index.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 
 import pkg from "../package.json";
+import { registerAudioCommand } from "./commands/audio.js";
 import { registerImageCommand } from "./commands/image.js";
 import { registerModelsCommand } from "./commands/models.js";
 import { registerTextCommand } from "./commands/text.js";
@@ -12,13 +13,14 @@ const program = new Command();
 program
   .name("ai")
   .description(
-    "A tiny, agent-native CLI for generating images, video and text with dead-simple commands, stdin support and predictable artifact outputs"
+    "A tiny, agent-native CLI for generating images, video, audio and text with dead-simple commands, stdin support and predictable artifact outputs"
   )
   .version(pkg.version);
 
 registerTextCommand(program);
 registerImageCommand(program);
 registerVideoCommand(program);
+registerAudioCommand(program);
 registerModelsCommand(program);
 
 program.parseAsync(process.argv).catch((err: unknown) => {

--- a/packages/ai-cli/src/lib/jobs.ts
+++ b/packages/ai-cli/src/lib/jobs.ts
@@ -18,6 +18,7 @@ export interface RunJobsOptions {
   noun: string;
   format: OutputFormat;
   outputPath?: string;
+  extension?: string;
   quiet?: boolean;
   json?: boolean;
   concurrency: number;
@@ -52,7 +53,16 @@ export async function runJobs(
   generate: (modelId: string) => Promise<GenerateResult>,
   opts: RunJobsOptions
 ): Promise<RunJobsResult> {
-  const { noun, format, outputPath, quiet, json, concurrency, display } = opts;
+  const {
+    noun,
+    format,
+    outputPath,
+    extension,
+    quiet,
+    json,
+    concurrency,
+    display,
+  } = opts;
 
   if (jobs.length === 1) {
     const { modelId } = jobs[0];
@@ -71,6 +81,7 @@ export async function runJobs(
           format,
           outputPath,
           outputId: generated.id,
+          extension,
           quiet: true,
           display,
         });
@@ -94,6 +105,7 @@ export async function runJobs(
           format,
           outputPath,
           outputId: generated.id,
+          extension,
           quiet,
           display,
         });
@@ -141,6 +153,7 @@ export async function runJobs(
           outputPath,
           outputId: generated.id,
           suffix,
+          extension,
           quiet: true,
           display: false,
         });

--- a/packages/ai-cli/src/lib/models.test.ts
+++ b/packages/ai-cli/src/lib/models.test.ts
@@ -32,6 +32,8 @@ describe("resolveModels", () => {
     expect(resolveModels("text")[0]).toContain("/");
     expect(resolveModels("image")[0]).toContain("/");
     expect(resolveModels("video")[0]).toContain("/");
+    expect(resolveModels("speech")[0]).toContain("/");
+    expect(resolveModels("transcription")[0]).toContain("/");
   });
 
   test("returns fully-qualified model as-is", () => {
@@ -129,6 +131,20 @@ describe("fetchGatewayModels", () => {
         tags: [],
       },
       {
+        id: "openai/tts-1",
+        name: "TTS 1",
+        owned_by: "openai",
+        type: "speech",
+        pricing: { speech_input_character_cost: "0.000015" },
+      },
+      {
+        id: "openai/whisper-1",
+        name: "Whisper",
+        owned_by: "openai",
+        type: "transcription",
+        pricing: { transcription_duration_cost_per_second: "0.000006" },
+      },
+      {
         id: "openai/text-embedding-3",
         name: "Embedding",
         owned_by: "openai",
@@ -160,8 +176,24 @@ describe("fetchGatewayModels", () => {
     expect(result.video[0].creator).toBe("google");
     expect(result.video[0].capabilities).toEqual(["video"]);
 
+    expect(result.speech).toHaveLength(1);
+    expect(result.speech[0].id).toBe("openai/tts-1");
+    expect(result.speech[0].creator).toBe("openai");
+    expect(result.speech[0].capabilities).toEqual(["speech"]);
+    expect(result.speech[0].pricing).toEqual({
+      speech_input_character_cost: "0.000015",
+    });
+
+    expect(result.transcription).toHaveLength(1);
+    expect(result.transcription[0].id).toBe("openai/whisper-1");
+    expect(result.transcription[0].creator).toBe("openai");
+    expect(result.transcription[0].capabilities).toEqual(["transcription"]);
+    expect(result.transcription[0].pricing).toEqual({
+      transcription_duration_cost_per_second: "0.000006",
+    });
+
     // embedding type is excluded
-    expect(result.all).toHaveLength(3);
+    expect(result.all).toHaveLength(5);
   });
 
   test("language models with image-generation tag appear in both text and image", async () => {
@@ -230,6 +262,8 @@ describe("fetchGatewayModels", () => {
     expect(result.text).toHaveLength(0);
     expect(result.image).toHaveLength(0);
     expect(result.video).toHaveLength(0);
+    expect(result.speech).toHaveLength(0);
+    expect(result.transcription).toHaveLength(0);
     expect(result.all).toHaveLength(0);
     expect(result.languageImageModelIds.size).toBe(0);
   });
@@ -244,6 +278,8 @@ describe("fetchGatewayModels", () => {
     expect(result.text).toHaveLength(0);
     expect(result.image).toHaveLength(0);
     expect(result.video).toHaveLength(0);
+    expect(result.speech).toHaveLength(0);
+    expect(result.transcription).toHaveLength(0);
     expect(result.all).toHaveLength(0);
   });
 

--- a/packages/ai-cli/src/lib/models.ts
+++ b/packages/ai-cli/src/lib/models.ts
@@ -1,9 +1,11 @@
-export type Modality = "text" | "image" | "video";
+export type Modality = "text" | "image" | "video" | "speech" | "transcription";
 
 const DEFAULTS: Record<Modality, string> = {
   text: process.env.AI_CLI_TEXT_MODEL ?? "openai/gpt-5.5",
   image: process.env.AI_CLI_IMAGE_MODEL ?? "openai/gpt-image-2",
   video: process.env.AI_CLI_VIDEO_MODEL ?? "bytedance/seedance-2.0",
+  speech: process.env.AI_CLI_SPEECH_MODEL ?? "openai/tts-1",
+  transcription: process.env.AI_CLI_TRANSCRIPTION_MODEL ?? "openai/whisper-1",
 };
 
 const GATEWAY_MODELS_URL = "https://ai-gateway.vercel.sh/v1/models";
@@ -13,6 +15,7 @@ export interface ModelPricing {
   input?: string;
   output?: string;
   image?: string;
+  [key: string]: unknown;
 }
 
 export interface ModelEntry {
@@ -28,6 +31,8 @@ export interface GatewayModels {
   text: ModelEntry[];
   image: ModelEntry[];
   video: ModelEntry[];
+  speech: ModelEntry[];
+  transcription: ModelEntry[];
   all: ModelEntry[];
   languageImageModelIds: Set<string>;
 }
@@ -40,9 +45,7 @@ interface RawGatewayModel {
   type?: string;
   tags?: string[];
   pricing?: {
-    input?: string;
-    output?: string;
-    image?: string;
+    [key: string]: unknown;
   };
 }
 
@@ -67,6 +70,8 @@ async function doFetch(): Promise<GatewayModels> {
     text: [],
     image: [],
     video: [],
+    speech: [],
+    transcription: [],
     all: [],
     languageImageModelIds: new Set(),
   };
@@ -97,6 +102,12 @@ async function doFetch(): Promise<GatewayModels> {
         case "video":
           capabilities.push("video");
           break;
+        case "speech":
+          capabilities.push("speech");
+          break;
+        case "transcription":
+          capabilities.push("transcription");
+          break;
         default:
           continue;
       }
@@ -105,14 +116,7 @@ async function doFetch(): Promise<GatewayModels> {
         m.owned_by ??
         (m.id.slice(0, Math.max(0, m.id.indexOf("/"))) || "other");
 
-      const pricing: ModelPricing | undefined =
-        m.pricing?.input || m.pricing?.output || m.pricing?.image
-          ? {
-              ...(m.pricing.input ? { input: m.pricing.input } : {}),
-              ...(m.pricing.output ? { output: m.pricing.output } : {}),
-              ...(m.pricing.image ? { image: m.pricing.image } : {}),
-            }
-          : undefined;
+      const pricing = normalizePricing(m.pricing);
 
       const entry: ModelEntry = {
         id: m.id,
@@ -128,6 +132,9 @@ async function doFetch(): Promise<GatewayModels> {
       if (capabilities.includes("text")) result.text.push(entry);
       if (capabilities.includes("image")) result.image.push(entry);
       if (capabilities.includes("video")) result.video.push(entry);
+      if (capabilities.includes("speech")) result.speech.push(entry);
+      if (capabilities.includes("transcription"))
+        result.transcription.push(entry);
 
       if (m.type === "language" && isImageGen) {
         result.languageImageModelIds.add(m.id);
@@ -141,6 +148,19 @@ async function doFetch(): Promise<GatewayModels> {
   }
 
   return result;
+}
+
+function normalizePricing(
+  pricing?: Record<string, unknown>
+): ModelPricing | undefined {
+  if (!pricing) return undefined;
+
+  const entries = Object.entries(pricing).filter(
+    ([, value]) => value != null && value !== ""
+  );
+  if (entries.length === 0) return undefined;
+
+  return Object.fromEntries(entries) as ModelPricing;
 }
 
 export function resolveModels(

--- a/packages/ai-cli/src/lib/output.test.ts
+++ b/packages/ai-cli/src/lib/output.test.ts
@@ -77,4 +77,21 @@ describe("writeOutput", () => {
       expect(readFileSync(path!, "utf8")).toBe("hello");
     });
   });
+
+  test("supports custom audio extensions when writing to a directory", async () => {
+    await withTempDir(async (dir) => {
+      const path = await writeOutput({
+        data: Buffer.from([1, 2, 3]),
+        format: "audio",
+        extension: ".wav",
+        outputPath: dir,
+        outputId: "speech_123",
+        quiet: true,
+      });
+
+      expect(path).not.toBeNull();
+      expect(basename(path!)).toBe("speech_123.wav");
+      expect(readFileSync(path!)).toEqual(Buffer.from([1, 2, 3]));
+    });
+  });
 });

--- a/packages/ai-cli/src/lib/output.ts
+++ b/packages/ai-cli/src/lib/output.ts
@@ -8,13 +8,14 @@ import {
   displayVideoFrame,
 } from "./kitty.js";
 
-export type OutputFormat = "md" | "txt" | "image" | "video";
+export type OutputFormat = "md" | "txt" | "image" | "video" | "audio";
 
 const DEFAULT_EXTENSIONS: Record<OutputFormat, string> = {
   md: ".md",
   txt: ".txt",
   image: ".png",
   video: ".mp4",
+  audio: ".mp3",
 };
 
 export interface WriteOutputOptions {
@@ -23,12 +24,17 @@ export interface WriteOutputOptions {
   outputPath?: string;
   outputId?: string;
   suffix?: string;
+  extension?: string;
   quiet?: boolean;
   display?: boolean;
 }
 
-function defaultFilename(format: OutputFormat, outputId?: string): string {
-  return `${filenameStem(outputId)}${DEFAULT_EXTENSIONS[format]}`;
+function defaultFilename(
+  format: OutputFormat,
+  outputId?: string,
+  extension?: string
+): string {
+  return `${filenameStem(outputId)}${extension ?? DEFAULT_EXTENSIONS[format]}`;
 }
 
 function filenameStem(outputId?: string): string {
@@ -56,7 +62,7 @@ function isDirectory(p: string): boolean {
 export async function writeOutput(
   opts: WriteOutputOptions
 ): Promise<string | null> {
-  const { data, format, outputId, suffix, quiet, display } = opts;
+  const { data, format, outputId, suffix, extension, quiet, display } = opts;
   const effectiveOutput = opts.outputPath ?? process.env.AI_CLI_OUTPUT_DIR;
   const buf = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
   const shouldDisplay =
@@ -70,7 +76,7 @@ export async function writeOutput(
     if (isDirectory(effectiveOutput)) {
       filePath = join(
         effectiveOutput,
-        addSuffix(defaultFilename(format, outputId), suffix)
+        addSuffix(defaultFilename(format, outputId, extension), suffix)
       );
     } else {
       filePath = addSuffix(effectiveOutput, suffix);
@@ -88,7 +94,10 @@ export async function writeOutput(
     return null;
   }
 
-  const filename = addSuffix(defaultFilename(format, outputId), suffix);
+  const filename = addSuffix(
+    defaultFilename(format, outputId, extension),
+    suffix
+  );
   const path = resolve(filename);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, buf);


### PR DESCRIPTION
## Summary
- add an audio command group with speak and transcribe subcommands
- use AI SDK speech/transcription models through Vercel AI Gateway
- document audio usage, defaults, env vars, and output behavior

```bash
Usage: ai audio [options] [command]

Generate speech or transcribe audio

Options:
  -h, --help                    display help for command

Commands:
  speak [options] [text]        Generate speech audio from text
  transcribe [options] [audio]  Transcribe audio to text
  help [command]                display help for command
```

`audio speak` accepts text from an argument or stdin and saves audio to `<id>.mp3` by default:

```bash
ai audio speak --voice alloy "Read this as a friendly update"
cat announcement.txt | ai audio speak --format wav -o announcement.wav
```

When using OpenAI speech models, `ai audio speak` defaults to the `alloy` voice unless `--voice` is provided.

#### audio transcribe

```
-f, --format <fmt>       Output format: md, txt (default: txt)
```

`audio transcribe` accepts a local path, `file://` URL, `http(s)://` URL or piped audio:

```bash
ai audio transcribe meeting.mp3
ai audio transcribe https://example.com/call.wav
cat voice-note.mp3 | ai audio transcribe -o transcript.txt
```

## Tests
- bun run typecheck
- bun run test
- bun run --cwd packages/ai-cli format:check
- bun run --cwd packages/ai-cli lint
- bun run --cwd packages/ai-cli build