### PR TITLE
fix: keep json output metadata-only

### DIFF
--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -49,6 +49,8 @@ All commands support:
 --json                   Output metadata as JSON
 ```
 
+When using `--json`, stdout contains only metadata. Generated text, image, video and audio outputs are written to files even when stdout is piped.
+
 Model IDs can be specified as `creator/model-name` or just `model-name` (resolved against models fetched from the gateway):
 
 ```bash

--- a/packages/ai-cli/src/commands/audio.ts
+++ b/packages/ai-cli/src/commands/audio.ts
@@ -239,7 +239,7 @@ function resolveTranscriptFormat(format?: string): OutputFormat {
 
 async function loadAudioInput(
   rawAudio: string | undefined,
-  stdin: Buffer | null
+  stdin: Uint8Array | null
 ): Promise<Uint8Array | URL> {
   if (stdin) return new Uint8Array(stdin);
   const audio = rawAudio?.trim();

--- a/packages/ai-cli/src/lib/h264-wasm.ts
+++ b/packages/ai-cli/src/lib/h264-wasm.ts
@@ -101,7 +101,7 @@ function getModule(): Promise<OpenH264Module> {
       const wasmBinary = readFileSync(wasmPath);
       const factory = (await import("./openh264.mjs")).default;
       return factory({
-        wasmBinary,
+        wasmBinary: new Uint8Array(wasmBinary),
         print: () => {},
         printErr: () => {},
       }) as Promise<OpenH264Module>;

--- a/packages/ai-cli/src/lib/jobs.test.ts
+++ b/packages/ai-cli/src/lib/jobs.test.ts
@@ -113,4 +113,47 @@ describe("runJobs", () => {
       }
     });
   });
+
+  test("json mode reports multi-run results in job order", async () => {
+    await withTempCwd(async () => {
+      const delays: Record<string, number> = {
+        slow: 30,
+        medium: 10,
+        fast: 0,
+      };
+
+      const stdout = await captureStdout(async () => {
+        await runJobs(
+          buildJobs(["slow", "medium", "fast"], 1),
+          async (modelId) => {
+            await new Promise((resolve) =>
+              setTimeout(resolve, delays[modelId] ?? 0)
+            );
+            return {
+              data: modelId,
+              id: modelId,
+            };
+          },
+          {
+            noun: "text",
+            format: "txt",
+            json: true,
+            quiet: true,
+            concurrency: 3,
+          }
+        );
+      });
+
+      const meta = JSON.parse(stdout.toString("utf8")) as {
+        results: Array<{ index: number; model: string }>;
+      };
+
+      expect(meta.results.map((r) => r.index)).toEqual([1, 2, 3]);
+      expect(meta.results.map((r) => r.model)).toEqual([
+        "slow",
+        "medium",
+        "fast",
+      ]);
+    });
+  });
 });

--- a/packages/ai-cli/src/lib/jobs.test.ts
+++ b/packages/ai-cli/src/lib/jobs.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { basename, join } from "path";
+
+import { buildJobs, runJobs } from "./jobs.js";
+
+async function withTempCwd<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const cwd = process.cwd();
+  const dir = mkdtempSync(join(tmpdir(), "ai-cli-jobs-"));
+  process.chdir(dir);
+  try {
+    return await fn(dir);
+  } finally {
+    process.chdir(cwd);
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function captureStdout(fn: () => Promise<void>): Promise<Buffer> {
+  const originalWrite = process.stdout.write;
+  const chunks: Uint8Array[] = [];
+  (
+    process.stdout as {
+      write: (chunk: string | Uint8Array) => boolean;
+    }
+  ).write = (chunk) => {
+    chunks.push(
+      typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk
+    );
+    return true;
+  };
+
+  try {
+    await fn();
+  } finally {
+    (
+      process.stdout as {
+        write: typeof originalWrite;
+      }
+    ).write = originalWrite;
+  }
+
+  return Buffer.concat(chunks);
+}
+
+describe("runJobs", () => {
+  test("json mode writes single binary output to a file and keeps stdout JSON-only", async () => {
+    await withTempCwd(async () => {
+      const stdout = await captureStdout(async () => {
+        await runJobs(
+          buildJobs(["openai/tts-1"], 1),
+          async () => ({
+            data: Buffer.from([1, 2, 3]),
+            id: "speech_123",
+          }),
+          {
+            noun: "audio",
+            format: "audio",
+            json: true,
+            quiet: true,
+            concurrency: 1,
+          }
+        );
+      });
+
+      expect(stdout[0]).toBe("{".charCodeAt(0));
+      const meta = JSON.parse(stdout.toString("utf8")) as {
+        count: number;
+        results: Array<{ file: string | null }>;
+      };
+      const file = meta.results[0]?.file;
+
+      expect(meta.count).toBe(1);
+      expect(file).not.toBeNull();
+      expect(basename(file!)).toBe("speech_123.mp3");
+      expect(readFileSync(file!)).toEqual(Buffer.from([1, 2, 3]));
+    });
+  });
+
+  test("json mode writes multi-run binary outputs to files and keeps stdout JSON-only", async () => {
+    await withTempCwd(async () => {
+      const stdout = await captureStdout(async () => {
+        await runJobs(
+          buildJobs(["openai/tts-1"], 2),
+          async () => ({
+            data: Buffer.from([4, 5, 6]),
+            id: "speech_456",
+          }),
+          {
+            noun: "audio",
+            format: "audio",
+            json: true,
+            quiet: true,
+            concurrency: 1,
+          }
+        );
+      });
+
+      expect(stdout[0]).toBe("{".charCodeAt(0));
+      const meta = JSON.parse(stdout.toString("utf8")) as {
+        count: number;
+        results: Array<{ file: string | null }>;
+      };
+
+      expect(meta.count).toBe(2);
+      expect(meta.results.map((r) => basename(r.file!)).sort()).toEqual([
+        "speech_456-1.mp3",
+        "speech_456-2.mp3",
+      ]);
+      for (const result of meta.results) {
+        expect(readFileSync(result.file!)).toEqual(Buffer.from([4, 5, 6]));
+      }
+    });
+  });
+});

--- a/packages/ai-cli/src/lib/jobs.ts
+++ b/packages/ai-cli/src/lib/jobs.ts
@@ -197,10 +197,11 @@ export async function runJobs(
 
   if (json) {
     const totalElapsed = Date.now() - start;
+    const orderedResults = [...results].sort((a, b) => a.index - b.index);
     const meta = {
       elapsed_ms: totalElapsed,
-      count: results.filter((r) => r.success).length,
-      results: results.map((r) => ({
+      count: orderedResults.filter((r) => r.success).length,
+      results: orderedResults.map((r) => ({
         index: r.index + 1,
         model: r.model,
         elapsed_ms: r.elapsed_ms,

--- a/packages/ai-cli/src/lib/jobs.ts
+++ b/packages/ai-cli/src/lib/jobs.ts
@@ -82,8 +82,9 @@ export async function runJobs(
           outputPath,
           outputId: generated.id,
           extension,
+          forceFile: true,
           quiet: true,
-          display,
+          display: false,
         });
         const meta = {
           elapsed_ms: elapsed,
@@ -120,6 +121,7 @@ export async function runJobs(
   const multi = new MultiProgress(quiet);
   const start = Date.now();
   const shouldDisplay =
+    !json &&
     display !== false &&
     (format === "image" || format === "video") &&
     process.stdout.isTTY &&
@@ -154,6 +156,7 @@ export async function runJobs(
           outputId: generated.id,
           suffix,
           extension,
+          forceFile: Boolean(json),
           quiet: true,
           display: false,
         });

--- a/packages/ai-cli/src/lib/output.ts
+++ b/packages/ai-cli/src/lib/output.ts
@@ -25,6 +25,7 @@ export interface WriteOutputOptions {
   outputId?: string;
   suffix?: string;
   extension?: string;
+  forceFile?: boolean;
   quiet?: boolean;
   display?: boolean;
 }
@@ -62,9 +63,21 @@ function isDirectory(p: string): boolean {
 export async function writeOutput(
   opts: WriteOutputOptions
 ): Promise<string | null> {
-  const { data, format, outputId, suffix, extension, quiet, display } = opts;
+  const {
+    data,
+    format,
+    outputId,
+    suffix,
+    extension,
+    forceFile,
+    quiet,
+    display,
+  } = opts;
   const effectiveOutput = opts.outputPath ?? process.env.AI_CLI_OUTPUT_DIR;
-  const buf = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
+  const buf =
+    typeof data === "string"
+      ? new TextEncoder().encode(data)
+      : new Uint8Array(data);
   const shouldDisplay =
     display !== false &&
     (format === "image" || format === "video") &&
@@ -89,7 +102,7 @@ export async function writeOutput(
     return filePath;
   }
 
-  if (!process.stdout.isTTY) {
+  if (!process.stdout.isTTY && !forceFile) {
     process.stdout.write(buf);
     return null;
   }
@@ -106,11 +119,15 @@ export async function writeOutput(
   return path;
 }
 
-async function showPreview(format: OutputFormat, buf: Buffer): Promise<void> {
+async function showPreview(
+  format: OutputFormat,
+  buf: Uint8Array
+): Promise<void> {
+  const preview = Buffer.from(buf);
   if (format === "video") {
-    await displayVideoFrame(buf);
+    await displayVideoFrame(preview);
   } else {
-    displayImage(buf);
+    displayImage(preview);
   }
 }
 

--- a/packages/ai-cli/src/lib/png.ts
+++ b/packages/ai-cli/src/lib/png.ts
@@ -13,7 +13,7 @@ export function encodePNG(
 
   // YUV420 -> RGB, with PNG filter byte per row
   const rowSize = width * 3 + 1;
-  const raw = Buffer.alloc(rowSize * height);
+  const raw = new Uint8Array(rowSize * height);
 
   for (let y = 0; y < height; y++) {
     raw[y * rowSize] = 0; // filter: None
@@ -36,7 +36,7 @@ export function encodePNG(
   const compressed = deflateSync(raw);
 
   // Build PNG file
-  const signature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+  const signature = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
 
   const ihdr = Buffer.alloc(13);
   ihdr.writeUInt32BE(width, 0);
@@ -47,23 +47,25 @@ export function encodePNG(
   ihdr[11] = 0; // filter
   ihdr[12] = 0; // interlace
 
-  const ihdrChunk = makeChunk("IHDR", ihdr);
-  const idatChunk = makeChunk("IDAT", compressed);
-  const iendChunk = makeChunk("IEND", Buffer.alloc(0));
+  const ihdrChunk = makeChunk("IHDR", new Uint8Array(ihdr));
+  const idatChunk = makeChunk("IDAT", new Uint8Array(compressed));
+  const iendChunk = makeChunk("IEND", new Uint8Array(0));
 
   return Buffer.concat([signature, ihdrChunk, idatChunk, iendChunk]);
 }
 
-function makeChunk(type: string, data: Buffer): Buffer {
-  const typeBytes = Buffer.from(type, "ascii");
+function makeChunk(type: string, data: Uint8Array): Uint8Array {
+  const typeBytes = new TextEncoder().encode(type);
   const len = Buffer.alloc(4);
   len.writeUInt32BE(data.length, 0);
 
   const crcInput = Buffer.concat([typeBytes, data]);
   const crc = Buffer.alloc(4);
-  crc.writeUInt32BE(crc32(crcInput), 0);
+  crc.writeUInt32BE(crc32(new Uint8Array(crcInput)), 0);
 
-  return Buffer.concat([len, typeBytes, data, crc]);
+  return new Uint8Array(
+    Buffer.concat([new Uint8Array(len), typeBytes, data, new Uint8Array(crc)])
+  );
 }
 
 const CRC_TABLE = new Uint32Array(256);
@@ -77,7 +79,7 @@ const CRC_TABLE = new Uint32Array(256);
   }
 }
 
-function crc32(buf: Buffer): number {
+function crc32(buf: Uint8Array): number {
   let crc = 0xffffffff;
   for (let i = 0; i < buf.length; i++) {
     crc = CRC_TABLE[(crc ^ buf[i]) & 0xff] ^ (crc >>> 8);

--- a/packages/ai-cli/src/lib/stdin.ts
+++ b/packages/ai-cli/src/lib/stdin.ts
@@ -1,9 +1,9 @@
-export async function readStdin(): Promise<Buffer | null> {
+export async function readStdin(): Promise<Uint8Array | null> {
   if (process.stdin.isTTY) return null;
 
   const first = await Promise.race([
-    new Promise<Buffer | null>((resolve) => {
-      process.stdin.once("data", (chunk) => resolve(Buffer.from(chunk)));
+    new Promise<Uint8Array | null>((resolve) => {
+      process.stdin.once("data", (chunk) => resolve(toBytes(chunk)));
       process.stdin.once("end", () => resolve(null));
       process.stdin.once("error", () => resolve(null));
     }),
@@ -17,15 +17,21 @@ export async function readStdin(): Promise<Buffer | null> {
     return null;
   }
 
-  const chunks: Buffer[] = [first];
+  const chunks: Uint8Array[] = [first];
   for await (const chunk of process.stdin) {
-    chunks.push(Buffer.from(chunk));
+    chunks.push(toBytes(chunk));
   }
 
   const buf = Buffer.concat(chunks);
-  return buf.length > 0 ? buf : null;
+  return buf.length > 0 ? new Uint8Array(buf) : null;
 }
 
-export function stdinAsText(buf: Buffer): string {
-  return buf.toString("utf-8");
+export function stdinAsText(buf: Uint8Array): string {
+  return new TextDecoder().decode(buf);
+}
+
+function toBytes(chunk: unknown): Uint8Array {
+  if (typeof chunk === "string") return new TextEncoder().encode(chunk);
+  if (chunk instanceof Uint8Array) return new Uint8Array(chunk);
+  return new TextEncoder().encode(String(chunk));
 }


### PR DESCRIPTION
- Keep `--json` stdout parseable by forcing generated artifacts to files and disabling previews.
- Add runJobs regression coverage for binary single and multi-output JSON runs.
- Normalize binary helper byte types so typecheck passes.