### PR TITLE
Add audio speak playback previews

### DIFF
--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -32,7 +32,7 @@ ai text --image screenshot.png "what is broken in this UI?"
 cat photo.png | ai text "describe this image"
 cat notes.txt | ai text "summarize this"
 git diff | ai text "explain these changes"
-echo "Ship the changelog" | ai audio speak -o changelog.wav
+echo "Ship the changelog" | ai audio speak -o changelog.mp3
 cat recording.mp3 | ai audio transcribe
 ```
 
@@ -123,7 +123,7 @@ ai audio transcribe recording.mp3
 #### audio speak
 
 ```
--f, --format <fmt>       Audio output format (default: wav)
+-f, --format <fmt>       Audio output format (default: mp3)
 --voice <voice>          Voice to use for speech generation
 --instructions <text>    Instructions for speech generation
 --speed <n>              Speech speed
@@ -132,14 +132,16 @@ ai audio transcribe recording.mp3
 --no-waveform            Disable accurate terminal waveform preview
 ```
 
-`audio speak` accepts text from an argument or stdin and saves audio to `<id>.wav` by default:
+`audio speak` accepts text from an argument or stdin and saves audio to `<id>.mp3` by default:
 
 ```bash
 ai audio speak --voice alloy "Read this as a friendly update"
-cat announcement.txt | ai audio speak -o announcement.wav
+cat announcement.txt | ai audio speak --format wav -o announcement.wav
 ```
 
 When using OpenAI speech models, `ai audio speak` defaults to the `alloy` voice unless `--voice` is provided.
+
+When `-o` points to a file with a known audio extension and `--format` is omitted, the extension selects the audio format. If both are provided, `--format` must match the filename extension.
 
 In interactive terminals, `audio speak` plays the generated audio after saving it and shows an accurate waveform derived from decoded audio samples. Use `--no-play` to skip playback and `--no-waveform` or `--quiet` to suppress the waveform. Playback and waveform previews are skipped for `--json` and binary stdout pipeline output. WAV output is decoded directly; MP3 and other encoded formats use a local decoder when available (`ffmpeg`, `mpg123`, `sox`, or `afconvert`).
 
@@ -189,7 +191,7 @@ When running in a terminal that supports the [Kitty graphics protocol](https://s
 
 - **text**: saves to `<id>.md` (interactive), stdout when piped
 - **image/video**: saves to `<id>.png` / `<id>.mp4` (interactive), raw binary stdout when piped
-- **audio speak**: saves to `<id>.wav` (interactive), raw binary stdout when piped
+- **audio speak**: saves to `<id>.mp3` (interactive), raw binary stdout when piped
 - **audio transcribe**: saves to `<id>.txt` (interactive), stdout when piped
 - **`-o <dir>`**: saves inside the directory with auto-generated names
 

--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -32,7 +32,7 @@ ai text --image screenshot.png "what is broken in this UI?"
 cat photo.png | ai text "describe this image"
 cat notes.txt | ai text "summarize this"
 git diff | ai text "explain these changes"
-echo "Ship the changelog" | ai audio speak -o changelog.mp3
+echo "Ship the changelog" | ai audio speak -o changelog.wav
 cat recording.mp3 | ai audio transcribe
 ```
 
@@ -123,21 +123,25 @@ ai audio transcribe recording.mp3
 #### audio speak
 
 ```
--f, --format <fmt>       Audio output format (default: mp3)
+-f, --format <fmt>       Audio output format (default: wav)
 --voice <voice>          Voice to use for speech generation
 --instructions <text>    Instructions for speech generation
 --speed <n>              Speech speed
 --language <code>        Language code (e.g. en, fr) or auto
+--no-play                Disable audio playback after generation
+--no-waveform            Disable accurate terminal waveform preview
 ```
 
-`audio speak` accepts text from an argument or stdin and saves audio to `<id>.mp3` by default:
+`audio speak` accepts text from an argument or stdin and saves audio to `<id>.wav` by default:
 
 ```bash
 ai audio speak --voice alloy "Read this as a friendly update"
-cat announcement.txt | ai audio speak --format wav -o announcement.wav
+cat announcement.txt | ai audio speak -o announcement.wav
 ```
 
 When using OpenAI speech models, `ai audio speak` defaults to the `alloy` voice unless `--voice` is provided.
+
+In interactive terminals, `audio speak` plays the generated audio after saving it and shows an accurate waveform derived from decoded audio samples. Use `--no-play` to skip playback and `--no-waveform` or `--quiet` to suppress the waveform. Playback and waveform previews are skipped for `--json` and binary stdout pipeline output. WAV output is decoded directly; MP3 and other encoded formats use a local decoder when available (`ffmpeg`, `mpg123`, `sox`, or `afconvert`).
 
 #### audio transcribe
 
@@ -185,7 +189,7 @@ When running in a terminal that supports the [Kitty graphics protocol](https://s
 
 - **text**: saves to `<id>.md` (interactive), stdout when piped
 - **image/video**: saves to `<id>.png` / `<id>.mp4` (interactive), raw binary stdout when piped
-- **audio speak**: saves to `<id>.mp3` (interactive), raw binary stdout when piped
+- **audio speak**: saves to `<id>.wav` (interactive), raw binary stdout when piped
 - **audio transcribe**: saves to `<id>.txt` (interactive), stdout when piped
 - **`-o <dir>`**: saves inside the directory with auto-generated names
 

--- a/packages/ai-cli/src/cli.test.ts
+++ b/packages/ai-cli/src/cli.test.ts
@@ -85,6 +85,7 @@ describe("cli integration", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("--voice");
     expect(stdout).toContain("--format");
+    expect(stdout).toContain("default: mp3");
     expect(stdout).toContain("--speed");
     expect(stdout).toContain("--no-play");
     expect(stdout).toContain("--no-waveform");

--- a/packages/ai-cli/src/cli.test.ts
+++ b/packages/ai-cli/src/cli.test.ts
@@ -86,6 +86,8 @@ describe("cli integration", () => {
     expect(stdout).toContain("--voice");
     expect(stdout).toContain("--format");
     expect(stdout).toContain("--speed");
+    expect(stdout).toContain("--no-play");
+    expect(stdout).toContain("--no-waveform");
   });
 
   test("audio transcribe --help exits 0 and lists flags", async () => {

--- a/packages/ai-cli/src/commands/audio.test.ts
+++ b/packages/ai-cli/src/commands/audio.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { resolveAudioFormat } from "./audio.js";
+import { resolveAudioFormat, shouldPreviewAudio } from "./audio.js";
 
 describe("resolveAudioFormat", () => {
   test("defaults to mp3", () => {
@@ -32,5 +32,30 @@ describe("resolveAudioFormat", () => {
     expect(() => resolveAudioFormat("mp3", "clip.wav")).toThrow(
       'does not match output file extension ".wav"'
     );
+  });
+});
+
+describe("shouldPreviewAudio", () => {
+  test("allows saved-file previews when stdout is piped and stderr is interactive", () => {
+    expect(
+      shouldPreviewAudio({ output: "clip.mp3" }, false, true, undefined)
+    ).toBe(true);
+  });
+
+  test("skips binary stdout pipeline output", () => {
+    expect(shouldPreviewAudio({}, false, true, undefined)).toBe(false);
+  });
+
+  test("skips json output and fully disabled previews", () => {
+    expect(
+      shouldPreviewAudio({ json: true, output: "clip.mp3" }, true, true)
+    ).toBe(false);
+    expect(
+      shouldPreviewAudio(
+        { output: "clip.mp3", play: false, waveform: false },
+        true,
+        true
+      )
+    ).toBe(false);
   });
 });

--- a/packages/ai-cli/src/commands/audio.test.ts
+++ b/packages/ai-cli/src/commands/audio.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { resolveAudioFormat } from "./audio.js";
+
+describe("resolveAudioFormat", () => {
+  test("defaults to mp3", () => {
+    expect(resolveAudioFormat()).toBe("mp3");
+  });
+
+  test("infers known audio formats from explicit output filenames", () => {
+    expect(resolveAudioFormat(undefined, "clip.wav")).toBe("wav");
+    expect(resolveAudioFormat(undefined, "clip.flac")).toBe("flac");
+  });
+
+  test("does not infer a format from output directories", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ai-cli-audio-format-"));
+    try {
+      expect(resolveAudioFormat(undefined, dir)).toBe("mp3");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores unknown output filename extensions", () => {
+    expect(resolveAudioFormat(undefined, "clip.audio")).toBe("mp3");
+  });
+
+  test("rejects conflicting explicit formats and output extensions", () => {
+    expect(() => resolveAudioFormat("mp3", "clip.wav")).toThrow(
+      'does not match output file extension ".wav"'
+    );
+  });
+});

--- a/packages/ai-cli/src/commands/audio.ts
+++ b/packages/ai-cli/src/commands/audio.ts
@@ -5,6 +5,7 @@ import { gateway } from "@ai-sdk/gateway";
 import { generateSpeech, transcribe } from "ai";
 import type { Command } from "commander";
 
+import { previewAudioOutputs } from "../lib/audio-preview.js";
 import { buildJobs, runJobs } from "../lib/jobs.js";
 import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import type { OutputFormat } from "../lib/output.js";
@@ -14,6 +15,7 @@ import { readStdin, stdinAsText } from "../lib/stdin.js";
 
 const DEFAULT_CONCURRENCY = 4;
 const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_AUDIO_FORMAT = "wav";
 
 interface SpeakOptions {
   model?: string;
@@ -27,6 +29,8 @@ interface SpeakOptions {
   concurrency?: string;
   quiet?: boolean;
   json?: boolean;
+  play?: boolean;
+  waveform?: boolean;
 }
 
 interface TranscribeOptions {
@@ -53,7 +57,7 @@ export function registerAudioCommand(program: Command) {
       "Speech model ID (creator/model-name), comma-separated for multi-model"
     )
     .option("-o, --output <path>", "Output file path or directory")
-    .option("-f, --format <fmt>", "Audio output format (default: mp3)")
+    .option("-f, --format <fmt>", "Audio output format (default: wav)")
     .option("--voice <voice>", "Voice to use for speech generation")
     .option("--instructions <text>", "Instructions for speech generation")
     .option("--speed <n>", "Speech speed")
@@ -65,6 +69,8 @@ export function registerAudioCommand(program: Command) {
     )
     .option("-q, --quiet", "Suppress progress output")
     .option("--json", "Output metadata as JSON")
+    .option("--no-play", "Disable audio playback after generation")
+    .option("--no-waveform", "Disable accurate terminal waveform preview")
     .action(async (rawText: string | undefined, opts: SpeakOptions) => {
       const text = rawText?.trim() || undefined;
       const stdin = await readStdin();
@@ -88,6 +94,10 @@ export function registerAudioCommand(program: Command) {
         ? parsePositiveInt(opts.count, "count")
         : 1;
       const jobs = buildJobs(models, countPerModel);
+      const previewAudio =
+        !opts.json &&
+        process.stdout.isTTY &&
+        (opts.play !== false || (opts.waveform !== false && !opts.quiet));
 
       const { total, failed } = await runJobs(
         jobs,
@@ -119,6 +129,14 @@ export function registerAudioCommand(program: Command) {
           concurrency: opts.concurrency
             ? parsePositiveInt(opts.concurrency, "concurrency")
             : DEFAULT_CONCURRENCY,
+          afterOutputs: previewAudio
+            ? (outputs) =>
+                previewAudioOutputs(outputs, {
+                  play: opts.play !== false,
+                  waveform: opts.waveform !== false,
+                  quiet: opts.quiet,
+                })
+            : undefined,
         }
       );
       if (failed === total) process.exit(1);
@@ -215,7 +233,7 @@ function buildSpeechText(
 }
 
 function resolveAudioFormat(format?: string): string {
-  if (!format) return "mp3";
+  if (!format) return DEFAULT_AUDIO_FORMAT;
 
   const normalized = format.trim().toLowerCase();
   if (!/^[a-z0-9][a-z0-9._-]*$/.test(normalized)) {

--- a/packages/ai-cli/src/commands/audio.ts
+++ b/packages/ai-cli/src/commands/audio.ts
@@ -104,10 +104,7 @@ export function registerAudioCommand(program: Command) {
         ? parsePositiveInt(opts.count, "count")
         : 1;
       const jobs = buildJobs(models, countPerModel);
-      const previewAudio =
-        !opts.json &&
-        process.stdout.isTTY &&
-        (opts.play !== false || (opts.waveform !== false && !opts.quiet));
+      const previewAudio = shouldPreviewAudio(opts);
 
       const { total, failed } = await runJobs(
         jobs,
@@ -262,6 +259,24 @@ export function resolveAudioFormat(
   }
 
   return normalized;
+}
+
+export function shouldPreviewAudio(
+  opts: Pick<SpeakOptions, "json" | "output" | "play" | "waveform" | "quiet">,
+  stdoutIsTTY = Boolean(process.stdout.isTTY),
+  stderrIsTTY = Boolean(process.stderr.isTTY),
+  envOutputDir = process.env.AI_CLI_OUTPUT_DIR
+): boolean {
+  if (opts.json) return false;
+
+  const playRequested = opts.play !== false;
+  const waveformRequested = opts.waveform !== false && !opts.quiet;
+  if (!playRequested && !waveformRequested) return false;
+
+  const hasSavedOutput = Boolean(opts.output || envOutputDir);
+  if (!stdoutIsTTY && !hasSavedOutput) return false;
+
+  return stderrIsTTY;
 }
 
 function audioFormatFromOutputPath(outputPath?: string): string | undefined {

--- a/packages/ai-cli/src/commands/audio.ts
+++ b/packages/ai-cli/src/commands/audio.ts
@@ -1,4 +1,6 @@
+import { statSync } from "fs";
 import { readFile } from "fs/promises";
+import { extname } from "path";
 import { fileURLToPath } from "url";
 
 import { gateway } from "@ai-sdk/gateway";
@@ -15,7 +17,15 @@ import { readStdin, stdinAsText } from "../lib/stdin.js";
 
 const DEFAULT_CONCURRENCY = 4;
 const DEFAULT_TIMEOUT_MS = 120_000;
-const DEFAULT_AUDIO_FORMAT = "wav";
+const DEFAULT_AUDIO_FORMAT = "mp3";
+const KNOWN_AUDIO_FORMATS = new Set([
+  "mp3",
+  "wav",
+  "opus",
+  "aac",
+  "flac",
+  "pcm",
+]);
 
 interface SpeakOptions {
   model?: string;
@@ -57,7 +67,7 @@ export function registerAudioCommand(program: Command) {
       "Speech model ID (creator/model-name), comma-separated for multi-model"
     )
     .option("-o, --output <path>", "Output file path or directory")
-    .option("-f, --format <fmt>", "Audio output format (default: wav)")
+    .option("-f, --format <fmt>", "Audio output format (default: mp3)")
     .option("--voice <voice>", "Voice to use for speech generation")
     .option("--instructions <text>", "Instructions for speech generation")
     .option("--speed <n>", "Speech speed")
@@ -84,7 +94,7 @@ export function registerAudioCommand(program: Command) {
         process.exit(1);
       }
 
-      const outputFormat = resolveAudioFormat(opts.format);
+      const outputFormat = resolveAudioFormat(opts.format, opts.output);
       const speed = opts.speed
         ? parseNonNegativeFloat(opts.speed, "speed")
         : undefined;
@@ -232,8 +242,12 @@ function buildSpeechText(
   return stdinText || text;
 }
 
-function resolveAudioFormat(format?: string): string {
-  if (!format) return DEFAULT_AUDIO_FORMAT;
+export function resolveAudioFormat(
+  format?: string,
+  outputPath?: string
+): string {
+  const outputPathFormat = audioFormatFromOutputPath(outputPath);
+  if (!format) return outputPathFormat ?? DEFAULT_AUDIO_FORMAT;
 
   const normalized = format.trim().toLowerCase();
   if (!/^[a-z0-9][a-z0-9._-]*$/.test(normalized)) {
@@ -241,8 +255,30 @@ function resolveAudioFormat(format?: string): string {
       `--format must be a valid audio format name (got "${format}")`
     );
   }
+  if (outputPathFormat && outputPathFormat !== normalized) {
+    throw new Error(
+      `--format "${normalized}" does not match output file extension ".${outputPathFormat}"`
+    );
+  }
 
   return normalized;
+}
+
+function audioFormatFromOutputPath(outputPath?: string): string | undefined {
+  if (!outputPath || isExistingDirectory(outputPath)) return undefined;
+
+  const extension = extname(outputPath).slice(1).toLowerCase();
+  if (!extension || !KNOWN_AUDIO_FORMATS.has(extension)) return undefined;
+
+  return extension;
+}
+
+function isExistingDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 function extensionForAudioFormat(format: string): string {

--- a/packages/ai-cli/src/lib/audio-preview.test.ts
+++ b/packages/ai-cli/src/lib/audio-preview.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+
+import { decodeWav, renderWaveformLine } from "./audio-preview.js";
+
+describe("decodeWav", () => {
+  test("decodes PCM samples into amplitudes", () => {
+    const wav = makePcm16Wav([0, 16_384, -32_768, 8_192], 4);
+    const decoded = decodeWav(wav);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded!.sampleRate).toBe(4);
+    expect(decoded!.channels).toBe(1);
+    expect(decoded!.durationMs).toBe(1000);
+    expect(Array.from(decoded!.amplitudes)).toEqual([0, 0.5, 1, 0.25]);
+  });
+
+  test("decodes WAV files with streaming data size markers", () => {
+    const wav = makePcm16Wav([0, 16_384, -32_768, 8_192], 4);
+    wav.writeUInt32LE(0xffffffff, 4);
+    wav.writeUInt32LE(0xffffffff, 40);
+
+    const decoded = decodeWav(wav);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded!.durationMs).toBe(1000);
+    expect(Array.from(decoded!.amplitudes)).toEqual([0, 0.5, 1, 0.25]);
+  });
+
+  test("returns null for unsupported audio data", () => {
+    expect(decodeWav(Buffer.from([0xff, 0xfb, 0x90, 0x64]))).toBeNull();
+  });
+});
+
+describe("renderWaveformLine", () => {
+  test("renders an accurate waveform from decoded amplitudes", () => {
+    const decoded = decodeWav(makePcm16Wav([0, 16_384, -32_768, 8_192], 4));
+    const line = renderWaveformLine(decoded!, 500, 48, "Playing audio");
+
+    expect(line).toContain("Playing audio");
+    expect(line).toContain("0:00 / 0:01");
+    expect(line).toMatch(new RegExp("[\\u2581-\\u2588]", "u"));
+    expect(line.length).toBeLessThanOrEqual(47);
+  });
+});
+
+function makePcm16Wav(samples: number[], sampleRate: number): Buffer {
+  const dataSize = samples.length * 2;
+  const wav = Buffer.alloc(44 + dataSize);
+
+  wav.write("RIFF", 0, "ascii");
+  wav.writeUInt32LE(36 + dataSize, 4);
+  wav.write("WAVE", 8, "ascii");
+  wav.write("fmt ", 12, "ascii");
+  wav.writeUInt32LE(16, 16);
+  wav.writeUInt16LE(1, 20);
+  wav.writeUInt16LE(1, 22);
+  wav.writeUInt32LE(sampleRate, 24);
+  wav.writeUInt32LE(sampleRate * 2, 28);
+  wav.writeUInt16LE(2, 32);
+  wav.writeUInt16LE(16, 34);
+  wav.write("data", 36, "ascii");
+  wav.writeUInt32LE(dataSize, 40);
+
+  for (let i = 0; i < samples.length; i++) {
+    wav.writeInt16LE(samples[i]!, 44 + i * 2);
+  }
+
+  return wav;
+}

--- a/packages/ai-cli/src/lib/audio-preview.test.ts
+++ b/packages/ai-cli/src/lib/audio-preview.test.ts
@@ -67,9 +67,17 @@ describe("playerCandidates", () => {
       .map((candidate) => candidate.args.join(" "));
 
     expect(powershellScripts[0]).toContain("System.Windows.Media.MediaPlayer");
-    expect(powershellScripts.join(" ")).toContain(
-      "System.Media.SoundPlayer"
+    expect(powershellScripts.join(" ")).toContain("System.Media.SoundPlayer");
+  });
+
+  test("prefers decode-capable Linux players for mp3 playback", () => {
+    const commands = playerCandidates("clip.mp3", "linux").map(
+      (candidate) => candidate.command
     );
+
+    expect(commands.slice(0, 3)).toEqual(["ffplay", "mpv", "play"]);
+    expect(commands).not.toContain("aplay");
+    expect(commands).not.toContain("paplay");
   });
 });
 

--- a/packages/ai-cli/src/lib/audio-preview.test.ts
+++ b/packages/ai-cli/src/lib/audio-preview.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { decodeWav, renderWaveformLine } from "./audio-preview.js";
+import {
+  decodeWav,
+  playerCandidates,
+  renderWaveformLine,
+} from "./audio-preview.js";
 
 describe("decodeWav", () => {
   test("decodes PCM samples into amplitudes", () => {
@@ -40,6 +44,32 @@ describe("renderWaveformLine", () => {
     expect(line).toContain("0:00 / 0:01");
     expect(line).toMatch(new RegExp("[\\u2581-\\u2588]", "u"));
     expect(line.length).toBeLessThanOrEqual(47);
+  });
+});
+
+describe("playerCandidates", () => {
+  test("uses Windows MediaPlayer for mp3 playback", () => {
+    const candidates = playerCandidates("clip.mp3", "win32");
+    const powershellScripts = candidates
+      .filter((candidate) => candidate.command === "powershell.exe")
+      .map((candidate) => candidate.args.join(" "));
+
+    expect(powershellScripts[0]).toContain("System.Windows.Media.MediaPlayer");
+    expect(powershellScripts.join(" ")).not.toContain(
+      "System.Media.SoundPlayer"
+    );
+  });
+
+  test("keeps Windows SoundPlayer as a wav fallback only", () => {
+    const candidates = playerCandidates("clip.wav", "win32");
+    const powershellScripts = candidates
+      .filter((candidate) => candidate.command === "powershell.exe")
+      .map((candidate) => candidate.args.join(" "));
+
+    expect(powershellScripts[0]).toContain("System.Windows.Media.MediaPlayer");
+    expect(powershellScripts.join(" ")).toContain(
+      "System.Media.SoundPlayer"
+    );
   });
 });
 

--- a/packages/ai-cli/src/lib/audio-preview.test.ts
+++ b/packages/ai-cli/src/lib/audio-preview.test.ts
@@ -4,6 +4,7 @@ import {
   decodeWav,
   playerCandidates,
   renderWaveformLine,
+  startWaveformRenderer,
 } from "./audio-preview.js";
 
 describe("decodeWav", () => {
@@ -43,7 +44,36 @@ describe("renderWaveformLine", () => {
     expect(line).toContain("Playing audio");
     expect(line).toContain("0:00 / 0:01");
     expect(line).toMatch(new RegExp("[\\u2581-\\u2588]", "u"));
-    expect(line.length).toBeLessThanOrEqual(47);
+    expect(stripAnsi(line).length).toBeLessThanOrEqual(47);
+  });
+
+  test("caps the waveform timeline on wide terminals", () => {
+    const decoded = decodeWav(makePcm16Wav([0, 16_384, -32_768, 8_192], 4));
+    const line = stripAnsi(
+      renderWaveformLine(decoded!, 500, 180, "Playing audio")
+    );
+    const suffix = " 0:00 / 0:01";
+    const waveform = line.slice("Playing audio ".length, -suffix.length);
+
+    expect(waveform).toHaveLength(80);
+  });
+});
+
+describe("startWaveformRenderer", () => {
+  test("hides the terminal cursor while playback is rendering", () => {
+    const decoded = decodeWav(makePcm16Wav([0, 16_384, -32_768, 8_192], 4));
+    const stderr = withStderrTTY(true, () =>
+      captureStderr(() => {
+        const stop = startWaveformRenderer(decoded!, "Playing audio");
+        stop(true);
+      })
+    );
+
+    expect(stderr).toContain("\x1b[?25l");
+    expect(stderr).toContain("\x1b[?25h");
+    expect(stderr.indexOf("\x1b[?25l")).toBeLessThan(
+      stderr.indexOf("\x1b[?25h")
+    );
   });
 });
 
@@ -104,4 +134,52 @@ function makePcm16Wav(samples: number[], sampleRate: number): Buffer {
   }
 
   return wav;
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function captureStderr(fn: () => void): string {
+  const originalWrite = process.stderr.write;
+  let output = "";
+  (
+    process.stderr as {
+      write: (chunk: string | Uint8Array) => boolean;
+    }
+  ).write = (chunk) => {
+    output +=
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  };
+
+  try {
+    fn();
+  } finally {
+    (
+      process.stderr as {
+        write: typeof originalWrite;
+      }
+    ).write = originalWrite;
+  }
+
+  return output;
+}
+
+function withStderrTTY<T>(isTTY: boolean, fn: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
+  Object.defineProperty(process.stderr, "isTTY", {
+    configurable: true,
+    value: isTTY,
+  });
+
+  try {
+    return fn();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(process.stderr, "isTTY", descriptor);
+    } else {
+      delete (process.stderr as { isTTY?: boolean }).isTTY;
+    }
+  }
 }

--- a/packages/ai-cli/src/lib/audio-preview.ts
+++ b/packages/ai-cli/src/lib/audio-preview.ts
@@ -1,0 +1,521 @@
+import { spawn } from "child_process";
+import { accessSync, constants, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { delimiter, isAbsolute, join, sep } from "path";
+
+import { isColorEnabled } from "./color.js";
+import type { RunJobOutput } from "./jobs.js";
+
+const WAVE_LEVELS = "\u2581\u2582\u2583\u2584\u2585\u2586\u2587\u2588";
+const MIN_WAVEFORM_WIDTH = 8;
+
+interface PlayerCommand {
+  command: string;
+  args: string[];
+}
+
+interface DecoderCommand {
+  command: string;
+  args: string[];
+}
+
+export interface DecodedWav {
+  sampleRate: number;
+  channels: number;
+  durationMs: number;
+  amplitudes: Float32Array;
+}
+
+export interface AudioPreviewOptions {
+  play: boolean;
+  waveform: boolean;
+  quiet?: boolean;
+}
+
+export async function previewAudioOutputs(
+  outputs: RunJobOutput[],
+  opts: AudioPreviewOptions
+): Promise<void> {
+  if (!opts.play && !opts.waveform) return;
+
+  for (const output of outputs) {
+    await previewAudioOutput(output, outputs.length, opts);
+  }
+}
+
+async function previewAudioOutput(
+  output: RunJobOutput,
+  outputCount: number,
+  opts: AudioPreviewOptions
+): Promise<void> {
+  const decoded = opts.waveform ? await decodeAudioForWaveform(output) : null;
+  const canRenderWaveform = Boolean(decoded && isTTY() && !opts.quiet);
+
+  if (opts.waveform && !decoded && isTTY() && !opts.quiet) {
+    process.stderr.write(
+      "Warning: could not decode audio for waveform preview; install ffmpeg or use --no-waveform\n"
+    );
+  }
+
+  if (!opts.play) {
+    if (decoded && isTTY() && !opts.quiet) {
+      process.stderr.write(
+        `${renderWaveformLine(decoded, decoded.durationMs, getColumns(), "Audio waveform")}\n`
+      );
+    }
+    return;
+  }
+
+  if (!output.file) {
+    if (!opts.quiet) {
+      process.stderr.write(
+        "Warning: audio playback requires a saved file; use -o or run in an interactive terminal\n"
+      );
+    }
+    return;
+  }
+
+  await playAudioFile(output.file, {
+    decoded: canRenderWaveform ? decoded : null,
+    label: outputCount > 1 ? `Playing audio ${output.label}` : "Playing audio",
+    quiet: opts.quiet,
+  });
+}
+
+async function decodeAudioForWaveform(
+  output: RunJobOutput
+): Promise<DecodedWav | null> {
+  if (Buffer.isBuffer(output.data)) {
+    const decoded = decodeWav(output.data);
+    if (decoded) return decoded;
+  }
+
+  if (!output.file) return null;
+  return decodeAudioFileForWaveform(output.file);
+}
+
+async function decodeAudioFileForWaveform(
+  file: string
+): Promise<DecodedWav | null> {
+  const dir = mkdtempSync(join(tmpdir(), "ai-cli-audio-"));
+  const wavPath = join(dir, "decoded.wav");
+
+  try {
+    for (const candidate of decoderCandidates(file, wavPath).filter(
+      (candidate) => commandExists(candidate.command)
+    )) {
+      const decoded = await runDecoder(candidate, wavPath);
+      if (decoded) return decoded;
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  return null;
+}
+
+function decoderCandidates(file: string, wavPath: string): DecoderCommand[] {
+  return [
+    {
+      command: "ffmpeg",
+      args: ["-v", "error", "-y", "-i", file, "-f", "wav", wavPath],
+    },
+    { command: "mpg123", args: ["-q", "-w", wavPath, file] },
+    { command: "sox", args: [file, wavPath] },
+    {
+      command: "afconvert",
+      args: ["-f", "WAVE", "-d", "LEI16", file, wavPath],
+    },
+  ];
+}
+
+function runDecoder(
+  candidate: DecoderCommand,
+  wavPath: string
+): Promise<DecodedWav | null> {
+  return new Promise((resolve) => {
+    const child = spawn(candidate.command, candidate.args, {
+      stdio: "ignore",
+    });
+
+    child.on("error", () => resolve(null));
+    child.on("exit", (code) => {
+      if (code !== 0) {
+        resolve(null);
+        return;
+      }
+
+      try {
+        resolve(decodeWav(readFileSync(wavPath)));
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+}
+
+interface PlayAudioFileOptions {
+  decoded: DecodedWav | null;
+  label: string;
+  quiet?: boolean;
+}
+
+async function playAudioFile(
+  file: string,
+  opts: PlayAudioFileOptions
+): Promise<void> {
+  const candidates = playerCandidates(file).filter((candidate) =>
+    commandExists(candidate.command)
+  );
+
+  if (candidates.length === 0) {
+    if (!opts.quiet) {
+      process.stderr.write(
+        "Warning: could not find an audio player for preview; use --no-play to suppress playback\n"
+      );
+    }
+    return;
+  }
+
+  for (const candidate of candidates) {
+    const played = await runPlayer(candidate, opts);
+    if (played) return;
+  }
+
+  if (!opts.quiet) {
+    process.stderr.write(
+      "Warning: audio player exited before playback completed; saved file is still available\n"
+    );
+  }
+}
+
+function playerCandidates(file: string): PlayerCommand[] {
+  if (process.platform === "darwin") {
+    return [{ command: "afplay", args: [file] }];
+  }
+
+  if (process.platform === "win32") {
+    return [
+      {
+        command: "powershell.exe",
+        args: [
+          "-NoProfile",
+          "-Command",
+          "$player = New-Object System.Media.SoundPlayer; $player.SoundLocation = $args[0]; $player.Load(); $player.PlaySync()",
+          file,
+        ],
+      },
+    ];
+  }
+
+  return [
+    { command: "paplay", args: [file] },
+    { command: "aplay", args: [file] },
+    {
+      command: "ffplay",
+      args: ["-nodisp", "-autoexit", "-loglevel", "quiet", file],
+    },
+    { command: "mpv", args: ["--no-video", "--really-quiet", file] },
+    { command: "play", args: ["-q", file] },
+  ];
+}
+
+function runPlayer(
+  candidate: PlayerCommand,
+  opts: PlayAudioFileOptions
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const stopRenderer = opts.decoded
+      ? startWaveformRenderer(opts.decoded, opts.label)
+      : null;
+    const child = spawn(candidate.command, candidate.args, {
+      stdio: "ignore",
+    });
+
+    child.on("error", () => {
+      stopRenderer?.(false);
+      resolve(false);
+    });
+    child.on("exit", (code) => {
+      stopRenderer?.(code === 0);
+      resolve(code === 0);
+    });
+  });
+}
+
+function startWaveformRenderer(
+  decoded: DecodedWav,
+  label: string
+): (complete: boolean) => void {
+  const start = Date.now();
+  const render = (elapsedMs: number) => {
+    process.stderr.write(
+      `\r${renderWaveformLine(decoded, elapsedMs, getColumns(), label)}\x1b[K`
+    );
+  };
+
+  render(0);
+  const interval = setInterval(() => {
+    render(Math.min(Date.now() - start, decoded.durationMs));
+  }, 50);
+
+  return (complete: boolean) => {
+    clearInterval(interval);
+    render(complete ? decoded.durationMs : Date.now() - start);
+    process.stderr.write("\n");
+  };
+}
+
+export function decodeWav(
+  data: Buffer | Uint8Array<ArrayBufferLike>
+): DecodedWav | null {
+  if (data.byteLength < 44) return null;
+
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  if (readAscii(view, 0, 4) !== "RIFF" || readAscii(view, 8, 4) !== "WAVE") {
+    return null;
+  }
+
+  let audioFormat = 0;
+  let channels = 0;
+  let sampleRate = 0;
+  let blockAlign = 0;
+  let bitsPerSample = 0;
+  let dataOffset = -1;
+  let dataSize = 0;
+
+  for (let offset = 12; offset + 8 <= view.byteLength; ) {
+    const chunkId = readAscii(view, offset, 4);
+    const rawChunkSize = view.getUint32(offset + 4, true);
+    const chunkDataOffset = offset + 8;
+    const chunkSize =
+      rawChunkSize === 0xffffffff && chunkId === "data"
+        ? view.byteLength - chunkDataOffset
+        : rawChunkSize;
+    const nextOffset =
+      rawChunkSize === 0xffffffff && chunkId === "data"
+        ? view.byteLength
+        : chunkDataOffset + chunkSize + (chunkSize % 2);
+    if (chunkDataOffset + chunkSize > view.byteLength) return null;
+
+    if (chunkId === "fmt ") {
+      if (chunkSize < 16) return null;
+      audioFormat = view.getUint16(chunkDataOffset, true);
+      channels = view.getUint16(chunkDataOffset + 2, true);
+      sampleRate = view.getUint32(chunkDataOffset + 4, true);
+      blockAlign = view.getUint16(chunkDataOffset + 12, true);
+      bitsPerSample = view.getUint16(chunkDataOffset + 14, true);
+    } else if (chunkId === "data") {
+      dataOffset = chunkDataOffset;
+      dataSize = chunkSize;
+    }
+
+    offset = nextOffset;
+  }
+
+  if (
+    dataOffset < 0 ||
+    channels <= 0 ||
+    sampleRate <= 0 ||
+    blockAlign <= 0 ||
+    (audioFormat !== 1 && audioFormat !== 3)
+  ) {
+    return null;
+  }
+
+  const bytesPerSample = bitsPerSample / 8;
+  if (!Number.isInteger(bytesPerSample) || bytesPerSample <= 0) return null;
+  if (blockAlign < bytesPerSample * channels) return null;
+
+  const frameCount = Math.floor(dataSize / blockAlign);
+  const amplitudes = new Float32Array(frameCount);
+
+  for (let frame = 0; frame < frameCount; frame++) {
+    const frameOffset = dataOffset + frame * blockAlign;
+    let amplitude = 0;
+
+    for (let channel = 0; channel < channels; channel++) {
+      const sampleOffset = frameOffset + channel * bytesPerSample;
+      const sample = readSample(view, sampleOffset, bitsPerSample, audioFormat);
+      if (sample === null) return null;
+      amplitude = Math.max(amplitude, Math.abs(sample));
+    }
+
+    amplitudes[frame] = Math.min(1, amplitude);
+  }
+
+  return {
+    sampleRate,
+    channels,
+    durationMs: (frameCount / sampleRate) * 1000,
+    amplitudes,
+  };
+}
+
+function readSample(
+  view: DataView,
+  offset: number,
+  bitsPerSample: number,
+  audioFormat: number
+): number | null {
+  if (offset + bitsPerSample / 8 > view.byteLength) return null;
+
+  if (audioFormat === 3) {
+    if (bitsPerSample === 32) return clampSample(view.getFloat32(offset, true));
+    if (bitsPerSample === 64) return clampSample(view.getFloat64(offset, true));
+    return null;
+  }
+
+  if (bitsPerSample === 8) return (view.getUint8(offset) - 128) / 128;
+  if (bitsPerSample === 16) return view.getInt16(offset, true) / 32768;
+  if (bitsPerSample === 24) {
+    let value =
+      view.getUint8(offset) |
+      (view.getUint8(offset + 1) << 8) |
+      (view.getUint8(offset + 2) << 16);
+    if (value & 0x800000) value |= 0xff000000;
+    return value / 8388608;
+  }
+  if (bitsPerSample === 32) return view.getInt32(offset, true) / 2147483648;
+
+  return null;
+}
+
+function clampSample(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(-1, Math.min(1, value));
+}
+
+export function renderWaveformLine(
+  decoded: DecodedWav,
+  elapsedMs: number,
+  columns: number,
+  label: string
+): string {
+  const suffix = ` ${formatTimestamp(elapsedMs)} / ${formatTimestamp(
+    decoded.durationMs
+  )}`;
+  const minTextWidth = suffix.length + MIN_WAVEFORM_WIDTH + 1;
+  const maxLabelWidth = Math.max(0, columns - minTextWidth - 1);
+  const displayLabel =
+    label.length > maxLabelWidth ? label.slice(0, maxLabelWidth) : label;
+  const prefix = displayLabel ? `${displayLabel} ` : "";
+  const width = columns - prefix.length - suffix.length - 1;
+
+  if (width < MIN_WAVEFORM_WIDTH) {
+    return `${displayLabel}${suffix}`.slice(0, Math.max(0, columns - 1));
+  }
+
+  return `${prefix}${waveformBars(decoded, elapsedMs, width)}${suffix}`;
+}
+
+function waveformBars(
+  decoded: DecodedWav,
+  elapsedMs: number,
+  width: number
+): string {
+  const playhead = Math.min(
+    width - 1,
+    Math.max(
+      0,
+      Math.floor((elapsedMs / Math.max(decoded.durationMs, 1)) * width)
+    )
+  );
+  let bars = "";
+
+  for (let i = 0; i < width; i++) {
+    const bar = barForAmplitude(columnAmplitude(decoded.amplitudes, i, width));
+    bars += i === playhead && isColorEnabled() ? `\x1b[7m${bar}\x1b[0m` : bar;
+  }
+
+  return bars;
+}
+
+function columnAmplitude(
+  amplitudes: Float32Array,
+  column: number,
+  width: number
+): number {
+  if (amplitudes.length === 0) return 0;
+
+  const start = Math.floor((column / width) * amplitudes.length);
+  const end = Math.max(
+    start + 1,
+    Math.floor(((column + 1) / width) * amplitudes.length)
+  );
+  let peak = 0;
+
+  for (let i = start; i < end && i < amplitudes.length; i++) {
+    peak = Math.max(peak, amplitudes[i] ?? 0);
+  }
+
+  return peak;
+}
+
+function barForAmplitude(amplitude: number): string {
+  const level = Math.max(
+    0,
+    Math.min(
+      WAVE_LEVELS.length - 1,
+      Math.round(amplitude * (WAVE_LEVELS.length - 1))
+    )
+  );
+  return WAVE_LEVELS[level]!;
+}
+
+function formatTimestamp(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function readAscii(view: DataView, offset: number, length: number): string {
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += String.fromCharCode(view.getUint8(offset + i));
+  }
+  return result;
+}
+
+function isTTY(): boolean {
+  return !!process.stderr.isTTY;
+}
+
+function getColumns(): number {
+  return (
+    (process.stderr as typeof process.stderr & { columns?: number }).columns ??
+    80
+  );
+}
+
+function commandExists(command: string): boolean {
+  if (command.includes(sep) || isAbsolute(command)) {
+    return isExecutable(command);
+  }
+
+  const pathEnv = process.env.PATH;
+  if (!pathEnv) return false;
+
+  const extensions =
+    process.platform === "win32"
+      ? ["", ...(process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";")]
+      : [""];
+
+  for (const dir of pathEnv.split(delimiter)) {
+    for (const ext of extensions) {
+      if (isExecutable(join(dir, `${command}${ext}`))) return true;
+    }
+  }
+
+  return false;
+}
+
+function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/ai-cli/src/lib/audio-preview.ts
+++ b/packages/ai-cli/src/lib/audio-preview.ts
@@ -48,10 +48,12 @@ async function previewAudioOutput(
   outputCount: number,
   opts: AudioPreviewOptions
 ): Promise<void> {
-  const decoded = opts.waveform ? await decodeAudioForWaveform(output) : null;
-  const canRenderWaveform = Boolean(decoded && isTTY() && !opts.quiet);
+  const canRenderWaveform = opts.waveform && isTTY() && !opts.quiet;
+  const decoded = canRenderWaveform
+    ? await decodeAudioForWaveform(output)
+    : null;
 
-  if (opts.waveform && !decoded && isTTY() && !opts.quiet) {
+  if (canRenderWaveform && !decoded) {
     process.stderr.write(
       "Warning: could not decode audio for waveform preview; install ffmpeg or use --no-waveform\n"
     );
@@ -76,7 +78,7 @@ async function previewAudioOutput(
   }
 
   await playAudioFile(output.file, {
-    decoded: canRenderWaveform ? decoded : null,
+    decoded,
     label: outputCount > 1 ? `Playing audio ${output.label}` : "Playing audio",
     quiet: opts.quiet,
   });

--- a/packages/ai-cli/src/lib/audio-preview.ts
+++ b/packages/ai-cli/src/lib/audio-preview.ts
@@ -226,10 +226,16 @@ export function playerCandidates(
     return candidates;
   }
 
+  return [...desktopPlayerCandidates(file), ...linuxPcmPlayerCandidates(file)];
+}
+
+function linuxPcmPlayerCandidates(file: string): PlayerCommand[] {
+  const extension = extname(file).toLowerCase();
+  if (extension !== ".wav" && extension !== ".pcm") return [];
+
   return [
     { command: "paplay", args: [file] },
     { command: "aplay", args: [file] },
-    ...desktopPlayerCandidates(file),
   ];
 }
 

--- a/packages/ai-cli/src/lib/audio-preview.ts
+++ b/packages/ai-cli/src/lib/audio-preview.ts
@@ -1,13 +1,31 @@
 import { spawn } from "child_process";
 import { accessSync, constants, mkdtempSync, readFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
-import { delimiter, isAbsolute, join, sep } from "path";
+import { delimiter, extname, isAbsolute, join, sep } from "path";
 
 import { isColorEnabled } from "./color.js";
 import type { RunJobOutput } from "./jobs.js";
 
 const WAVE_LEVELS = "\u2581\u2582\u2583\u2584\u2585\u2586\u2587\u2588";
 const MIN_WAVEFORM_WIDTH = 8;
+const WINDOWS_MEDIA_PLAYER_SCRIPT = [
+  "$ErrorActionPreference = 'Stop'",
+  "Add-Type -AssemblyName PresentationCore",
+  "$done = New-Object System.Threading.ManualResetEvent($false)",
+  "$state = @{ Failed = $false }",
+  "$player = New-Object System.Windows.Media.MediaPlayer",
+  "$player.add_MediaEnded({ $done.Set() | Out-Null })",
+  "$player.add_MediaFailed({ $state.Failed = $true; $done.Set() | Out-Null })",
+  "$path = (Resolve-Path -LiteralPath $args[0]).ProviderPath",
+  "$player.Open([System.Uri]::new($path))",
+  "$player.Play()",
+  "$limit = [DateTime]::UtcNow.AddSeconds(10)",
+  "while (-not $player.NaturalDuration.HasTimeSpan -and -not $state.Failed -and [DateTime]::UtcNow -lt $limit) { Start-Sleep -Milliseconds 50 }",
+  "$timeout = if ($player.NaturalDuration.HasTimeSpan) { [TimeSpan]::FromMilliseconds($player.NaturalDuration.TimeSpan.TotalMilliseconds + 1000) } else { [TimeSpan]::FromSeconds(300) }",
+  "$done.WaitOne($timeout) | Out-Null",
+  "$player.Close()",
+  "if ($state.Failed) { exit 1 }",
+].join("; ");
 
 interface PlayerCommand {
   command: string;
@@ -191,28 +209,51 @@ async function playAudioFile(
   }
 }
 
-function playerCandidates(file: string): PlayerCommand[] {
-  if (process.platform === "darwin") {
+export function playerCandidates(
+  file: string,
+  platform = process.platform
+): PlayerCommand[] {
+  if (platform === "darwin") {
     return [{ command: "afplay", args: [file] }];
   }
 
-  if (process.platform === "win32") {
-    return [
-      {
-        command: "powershell.exe",
-        args: [
-          "-NoProfile",
-          "-Command",
-          "$player = New-Object System.Media.SoundPlayer; $player.SoundLocation = $args[0]; $player.Load(); $player.PlaySync()",
-          file,
-        ],
-      },
-    ];
+  if (platform === "win32") {
+    const candidates = [windowsMediaPlayerCandidate(file)];
+    if (extname(file).toLowerCase() === ".wav") {
+      candidates.push(windowsSoundPlayerCandidate(file));
+    }
+    candidates.push(...desktopPlayerCandidates(file));
+    return candidates;
   }
 
   return [
     { command: "paplay", args: [file] },
     { command: "aplay", args: [file] },
+    ...desktopPlayerCandidates(file),
+  ];
+}
+
+function windowsMediaPlayerCandidate(file: string): PlayerCommand {
+  return {
+    command: "powershell.exe",
+    args: ["-NoProfile", "-Sta", "-Command", WINDOWS_MEDIA_PLAYER_SCRIPT, file],
+  };
+}
+
+function windowsSoundPlayerCandidate(file: string): PlayerCommand {
+  return {
+    command: "powershell.exe",
+    args: [
+      "-NoProfile",
+      "-Command",
+      "$player = New-Object System.Media.SoundPlayer; $player.SoundLocation = $args[0]; $player.Load(); $player.PlaySync()",
+      file,
+    ],
+  };
+}
+
+function desktopPlayerCandidates(file: string): PlayerCommand[] {
+  return [
     {
       command: "ffplay",
       args: ["-nodisp", "-autoexit", "-loglevel", "quiet", file],

--- a/packages/ai-cli/src/lib/audio-preview.ts
+++ b/packages/ai-cli/src/lib/audio-preview.ts
@@ -8,6 +8,9 @@ import type { RunJobOutput } from "./jobs.js";
 
 const WAVE_LEVELS = "\u2581\u2582\u2583\u2584\u2585\u2586\u2587\u2588";
 const MIN_WAVEFORM_WIDTH = 8;
+const MAX_WAVEFORM_WIDTH = 80;
+const HIDE_CURSOR = "\x1b[?25l";
+const SHOW_CURSOR = "\x1b[?25h";
 const WINDOWS_MEDIA_PLAYER_SCRIPT = [
   "$ErrorActionPreference = 'Stop'",
   "Add-Type -AssemblyName PresentationCore",
@@ -292,11 +295,12 @@ function runPlayer(
   });
 }
 
-function startWaveformRenderer(
+export function startWaveformRenderer(
   decoded: DecodedWav,
   label: string
 ): (complete: boolean) => void {
   const start = Date.now();
+  const restoreCursor = hideTerminalCursor();
   const render = (elapsedMs: number) => {
     process.stderr.write(
       `\r${renderWaveformLine(decoded, elapsedMs, getColumns(), label)}\x1b[K`
@@ -312,6 +316,26 @@ function startWaveformRenderer(
     clearInterval(interval);
     render(complete ? decoded.durationMs : Date.now() - start);
     process.stderr.write("\n");
+    restoreCursor();
+  };
+}
+
+function hideTerminalCursor(): () => void {
+  if (!isTTY()) return () => {};
+
+  let restored = false;
+  const restore = () => {
+    if (restored) return;
+    restored = true;
+    process.stderr.write(SHOW_CURSOR);
+  };
+
+  process.stderr.write(HIDE_CURSOR);
+  process.once("exit", restore);
+
+  return () => {
+    process.off("exit", restore);
+    restore();
   };
 }
 
@@ -449,12 +473,13 @@ export function renderWaveformLine(
   const displayLabel =
     label.length > maxLabelWidth ? label.slice(0, maxLabelWidth) : label;
   const prefix = displayLabel ? `${displayLabel} ` : "";
-  const width = columns - prefix.length - suffix.length - 1;
+  const availableWidth = columns - prefix.length - suffix.length - 1;
 
-  if (width < MIN_WAVEFORM_WIDTH) {
+  if (availableWidth < MIN_WAVEFORM_WIDTH) {
     return `${displayLabel}${suffix}`.slice(0, Math.max(0, columns - 1));
   }
 
+  const width = Math.min(availableWidth, MAX_WAVEFORM_WIDTH);
   return `${prefix}${waveformBars(decoded, elapsedMs, width)}${suffix}`;
 }
 

--- a/packages/ai-cli/src/lib/jobs.test.ts
+++ b/packages/ai-cli/src/lib/jobs.test.ts
@@ -73,7 +73,7 @@ describe("runJobs", () => {
 
       expect(meta.count).toBe(1);
       expect(file).not.toBeNull();
-      expect(basename(file!)).toBe("speech_123.wav");
+      expect(basename(file!)).toBe("speech_123.mp3");
       expect(readFileSync(file!)).toEqual(Buffer.from([1, 2, 3]));
     });
   });
@@ -105,8 +105,8 @@ describe("runJobs", () => {
 
       expect(meta.count).toBe(2);
       expect(meta.results.map((r) => basename(r.file!)).sort()).toEqual([
-        "speech_456-1.wav",
-        "speech_456-2.wav",
+        "speech_456-1.mp3",
+        "speech_456-2.mp3",
       ]);
       for (const result of meta.results) {
         expect(readFileSync(result.file!)).toEqual(Buffer.from([4, 5, 6]));

--- a/packages/ai-cli/src/lib/jobs.test.ts
+++ b/packages/ai-cli/src/lib/jobs.test.ts
@@ -73,7 +73,7 @@ describe("runJobs", () => {
 
       expect(meta.count).toBe(1);
       expect(file).not.toBeNull();
-      expect(basename(file!)).toBe("speech_123.mp3");
+      expect(basename(file!)).toBe("speech_123.wav");
       expect(readFileSync(file!)).toEqual(Buffer.from([1, 2, 3]));
     });
   });
@@ -105,8 +105,8 @@ describe("runJobs", () => {
 
       expect(meta.count).toBe(2);
       expect(meta.results.map((r) => basename(r.file!)).sort()).toEqual([
-        "speech_456-1.mp3",
-        "speech_456-2.mp3",
+        "speech_456-1.wav",
+        "speech_456-2.wav",
       ]);
       for (const result of meta.results) {
         expect(readFileSync(result.file!)).toEqual(Buffer.from([4, 5, 6]));
@@ -153,6 +153,43 @@ describe("runJobs", () => {
         "slow",
         "medium",
         "fast",
+      ]);
+    });
+  });
+
+  test("passes saved outputs to afterOutputs in job order", async () => {
+    await withTempCwd(async (dir) => {
+      const seen: Array<{ model: string; file: string | null }> = [];
+
+      await runJobs(
+        buildJobs(["slow", "fast"], 1),
+        async (modelId) => {
+          if (modelId === "slow") {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+          }
+          return {
+            data: modelId,
+            id: modelId,
+          };
+        },
+        {
+          noun: "text",
+          format: "txt",
+          outputPath: dir,
+          quiet: true,
+          concurrency: 2,
+          afterOutputs: (outputs) => {
+            seen.push(
+              ...outputs.map((o) => ({ model: o.model, file: o.file }))
+            );
+          },
+        }
+      );
+
+      expect(seen.map((o) => o.model)).toEqual(["slow", "fast"]);
+      expect(seen.map((o) => basename(o.file!))).toEqual([
+        "slow-1.txt",
+        "fast-2.txt",
       ]);
     });
   });

--- a/packages/ai-cli/src/lib/jobs.ts
+++ b/packages/ai-cli/src/lib/jobs.ts
@@ -23,6 +23,16 @@ export interface RunJobsOptions {
   json?: boolean;
   concurrency: number;
   display?: boolean;
+  afterOutputs?: (outputs: RunJobOutput[]) => Promise<void> | void;
+}
+
+export interface RunJobOutput {
+  index: number;
+  model: string;
+  label: string;
+  data: Buffer | string;
+  file: string | null;
+  elapsed_ms: number;
 }
 
 export function buildJobs(models: string[], countPerModel: number): Job[] {
@@ -62,10 +72,12 @@ export async function runJobs(
     json,
     concurrency,
     display,
+    afterOutputs,
   } = opts;
 
   if (jobs.length === 1) {
-    const { modelId } = jobs[0];
+    const job = jobs[0];
+    const { modelId } = job;
     const progress = new Progress(quiet);
     const start = Date.now();
     progress.start(`Generating ${noun} with ${modelId}`);
@@ -101,7 +113,7 @@ export async function runJobs(
         };
         process.stdout.write(JSON.stringify(meta, null, 2) + "\n");
       } else {
-        await writeOutput({
+        const path = await writeOutput({
           data: generated.data,
           format,
           outputPath,
@@ -110,6 +122,16 @@ export async function runJobs(
           quiet,
           display,
         });
+        await afterOutputs?.([
+          {
+            index: 0,
+            model: modelId,
+            label: job.label,
+            data: generated.data,
+            file: path,
+            elapsed_ms: elapsed,
+          },
+        ]);
       }
     } catch (err) {
       progress.stop();
@@ -138,6 +160,7 @@ export async function runJobs(
     elapsed_ms: number;
     file: string | null;
   }[] = [];
+  const outputs: RunJobOutput[] = [];
   const pendingDisplayBuffers: Buffer[] = [];
 
   await pMap(
@@ -176,6 +199,14 @@ export async function runJobs(
           elapsed_ms: genElapsed,
           file: path,
         });
+        outputs.push({
+          index: i,
+          model: job.modelId,
+          label: job.label,
+          data: generated.data,
+          file: path,
+          elapsed_ms: genElapsed,
+        });
       } catch (err: unknown) {
         const genElapsed = Date.now() - genStart;
         const msg = err instanceof Error ? err.message : String(err);
@@ -210,6 +241,10 @@ export async function runJobs(
       })),
     };
     process.stdout.write(JSON.stringify(meta, null, 2) + "\n");
+  }
+
+  if (!json && afterOutputs) {
+    await afterOutputs([...outputs].sort((a, b) => a.index - b.index));
   }
 
   for (const buf of pendingDisplayBuffers) {

--- a/packages/ai-cli/src/lib/jobs.ts
+++ b/packages/ai-cli/src/lib/jobs.ts
@@ -160,6 +160,7 @@ export async function runJobs(
     elapsed_ms: number;
     file: string | null;
   }[] = [];
+  const collectOutputs = !json && Boolean(afterOutputs);
   const outputs: RunJobOutput[] = [];
   const pendingDisplayBuffers: Buffer[] = [];
 
@@ -199,14 +200,16 @@ export async function runJobs(
           elapsed_ms: genElapsed,
           file: path,
         });
-        outputs.push({
-          index: i,
-          model: job.modelId,
-          label: job.label,
-          data: generated.data,
-          file: path,
-          elapsed_ms: genElapsed,
-        });
+        if (collectOutputs) {
+          outputs.push({
+            index: i,
+            model: job.modelId,
+            label: job.label,
+            data: generated.data,
+            file: path,
+            elapsed_ms: genElapsed,
+          });
+        }
       } catch (err: unknown) {
         const genElapsed = Date.now() - genStart;
         const msg = err instanceof Error ? err.message : String(err);
@@ -243,8 +246,8 @@ export async function runJobs(
     process.stdout.write(JSON.stringify(meta, null, 2) + "\n");
   }
 
-  if (!json && afterOutputs) {
-    await afterOutputs([...outputs].sort((a, b) => a.index - b.index));
+  if (collectOutputs) {
+    await afterOutputs?.([...outputs].sort((a, b) => a.index - b.index));
   }
 
   for (const buf of pendingDisplayBuffers) {

--- a/packages/ai-cli/src/lib/output.ts
+++ b/packages/ai-cli/src/lib/output.ts
@@ -15,7 +15,7 @@ const DEFAULT_EXTENSIONS: Record<OutputFormat, string> = {
   txt: ".txt",
   image: ".png",
   video: ".mp4",
-  audio: ".mp3",
+  audio: ".wav",
 };
 
 export interface WriteOutputOptions {

--- a/packages/ai-cli/src/lib/output.ts
+++ b/packages/ai-cli/src/lib/output.ts
@@ -15,7 +15,7 @@ const DEFAULT_EXTENSIONS: Record<OutputFormat, string> = {
   txt: ".txt",
   image: ".png",
   video: ".mp4",
-  audio: ".wav",
+  audio: ".mp3",
 };
 
 export interface WriteOutputOptions {


### PR DESCRIPTION
- Play generated speech by default with opt-out flags.
- Render accurate waveforms from decoded WAV and MP3 audio samples.
- Document behavior and cover audio preview/job callback paths.