### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,14 @@ Then install that specific version (e.g. `bun add --cwd packages/ai-cli <package
 
 ## Documentation
 
-When making any user-facing change (new command, new flag, changed behavior, renamed option, etc.), update the documentation in `packages/ai-cli/README.md` in the same PR. A user-facing change without a docs update is incomplete.
+When making any user-facing change (new command, new flag, changed behavior, renamed option, release note, website copy change, etc.), update every relevant user-facing documentation surface in the same PR:
+
+- `packages/ai-cli/README.md` for the npm/package README
+- `apps/web/docs/` for website documentation
+- `apps/web/components/landing/` and other website copy when the landing page or marketing copy should reflect the change
+- `CHANGELOG.md` for release-facing changes
+
+A user-facing change without matching README and website/docs updates is incomplete.
 
 ## Type Checking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Contributors
 
+- @atinux
+- @piotrjoniec
 - @ctate
 
 <!-- release:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.4.0
+
+<!-- release:start -->
+
+### New Features
+
+- **Audio commands** - `ai audio speak` generates speech from text and `ai audio transcribe` transcribes local files, URLs and piped audio (#66)
+- **Audio playback previews** - generated speech plays automatically in interactive terminals with accurate waveform previews and opt-out flags (#68)
+
+### Improvements
+
+- **Longer image timeout** - image generation requests now use a 300-second timeout to better accommodate slower models (#64)
+
+### Bug Fixes
+
+- **Metadata-only JSON output** - `--json` keeps stdout parseable by forcing generated artifacts to files and disabling previews (#67)
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
 ## 0.3.1
 
 <!-- release:start -->

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -6,19 +6,19 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "ai-cli",
-  description: "Generate text, images, and video from the terminal.",
+  description: "Generate text, images, video, and audio from the terminal.",
   openGraph: {
     type: "website",
     locale: "en_US",
     siteName: "ai-cli",
     title: "ai-cli",
-    description: "Generate text, images, and video from the terminal.",
+    description: "Generate text, images, video, and audio from the terminal.",
     images: [{ url: "/og", width: 1200, height: 630, alt: "ai-cli" }],
   },
   twitter: {
     card: "summary_large_image",
     title: "ai-cli",
-    description: "Generate text, images, and video from the terminal.",
+    description: "Generate text, images, video, and audio from the terminal.",
     images: ["/og"],
   },
 };

--- a/apps/web/components/landing/bento.tsx
+++ b/apps/web/components/landing/bento.tsx
@@ -8,7 +8,7 @@ const items: readonly item[] = [
   {
     id: "001",
     title: "Inline preview",
-    body: "Generated images and video frames display directly in your terminal using the Kitty graphics protocol. Supports Kitty, Ghostty, WezTerm, Warp, and iTerm2.",
+    body: "Generated images, video frames, and speech previews display directly in your terminal. Visual previews use the Kitty graphics protocol where supported.",
   },
   {
     id: "002",

--- a/apps/web/components/landing/features.tsx
+++ b/apps/web/components/landing/features.tsx
@@ -13,8 +13,8 @@ interface row {
 const multimodelrows: readonly row[] = [
   { tone: "cmd", text: '$ ai image "a sunset" -m "gpt-image-2,flux-2-pro"' },
   { tone: "dim", text: "" },
-  { tone: "code", text: "Saved to /Users/you/output-1.png (3.2s)" },
-  { tone: "code", text: "Saved to /Users/you/output-2.png (4.7s)" },
+  { tone: "code", text: "Saved to /Users/you/resp_img_1.png (3.2s)" },
+  { tone: "code", text: "Saved to /Users/you/resp_img_2.png (4.7s)" },
 ];
 
 const pipingrows: readonly row[] = [
@@ -27,20 +27,22 @@ const pipingrows: readonly row[] = [
   { tone: "code", text: "  3. Removes deprecated OAuth1 flow" },
   { tone: "dim", text: "" },
   { tone: "cmd", text: '$ ai image "a dragon" | ai video "animate this"' },
-  { tone: "code", text: "Saved to /Users/you/output.mp4" },
+  { tone: "code", text: "Saved to /Users/you/resp_video.mp4" },
+  { tone: "dim", text: "" },
+  { tone: "cmd", text: '$ echo "Ship the changelog" | ai audio speak' },
+  { tone: "code", text: "Saved to /Users/you/resp_speech.mp3" },
 ];
 
 const modelrows: readonly row[] = [
-  { tone: "cmd", text: "$ ai models --type image" },
+  { tone: "cmd", text: "$ ai models --type audio" },
   { tone: "dim", text: "" },
   { tone: "dim", text: "  openai" },
-  { tone: "code", text: "    gpt-image-2" },
-  { tone: "code", text: "    gpt-image-1" },
-  { tone: "dim", text: "  bfl" },
-  { tone: "code", text: "    flux-2-pro" },
-  { tone: "code", text: "    flux-kontext-pro" },
-  { tone: "dim", text: "  google" },
-  { tone: "code", text: "    imagen-4.0-generate-001" },
+  { tone: "code", text: "    tts-1" },
+  { tone: "code", text: "    whisper-1" },
+  { tone: "dim", text: "  speech" },
+  { tone: "code", text: "    text-to-speech models" },
+  { tone: "dim", text: "  transcription" },
+  { tone: "code", text: "    speech-to-text models" },
   { tone: "dim", text: "  ...and more" },
 ];
 
@@ -141,11 +143,11 @@ export function Features() {
           <Spotlight
             tone="ash"
             title="Pipe everything."
-            description="Pipe text in as context, pipe images into video generation, chain commands together. Raw output on stdout when piped, file saves when interactive."
+            description="Pipe text in as context, pipe images into video generation, turn text into speech, or transcribe piped audio. Raw output on stdout when piped, file saves when interactive."
             bullets={[
               "text stdin becomes prompt context",
-              "binary stdin for image-to-image and image-to-video",
-              "chain: ai image | ai video",
+              "binary stdin for image, video, and audio workflows",
+              "chain: ai image | ai video, or pipe text to ai audio speak",
             ]}
             flip
             window={<Panel rows={pipingrows} />}
@@ -154,9 +156,9 @@ export function Features() {
           <Spotlight
             tone="iron"
             title="Hundreds of models, one key."
-            description="Access text, image, and video models from OpenAI, Anthropic, Google, Black Forest Labs, ByteDance, and more through Vercel AI Gateway."
+            description="Access text, image, video, speech, and transcription models from OpenAI, Anthropic, Google, Black Forest Labs, ByteDance, and more through Vercel AI Gateway."
             bullets={[
-              "short names resolve automatically: flux-2-pro, gpt-5.5",
+              "short names resolve automatically: flux-2-pro, gpt-5.5, tts-1",
               "live model listing from the gateway",
               "per-type defaults configurable via env vars",
             ]}

--- a/apps/web/components/landing/features.tsx
+++ b/apps/web/components/landing/features.tsx
@@ -13,8 +13,8 @@ interface row {
 const multimodelrows: readonly row[] = [
   { tone: "cmd", text: '$ ai image "a sunset" -m "gpt-image-2,flux-2-pro"' },
   { tone: "dim", text: "" },
-  { tone: "code", text: "Saved to /Users/you/resp_img_1.png (3.2s)" },
-  { tone: "code", text: "Saved to /Users/you/resp_img_2.png (4.7s)" },
+  { tone: "code", text: "Saved to /Users/you/resp_img_a-1.png (3.2s)" },
+  { tone: "code", text: "Saved to /Users/you/resp_img_b-2.png (4.7s)" },
 ];
 
 const pipingrows: readonly row[] = [
@@ -36,13 +36,16 @@ const pipingrows: readonly row[] = [
 const modelrows: readonly row[] = [
   { tone: "cmd", text: "$ ai models --type audio" },
   { tone: "dim", text: "" },
+  { tone: "dim", text: "Speech models (8):" },
+  { tone: "dim", text: "" },
   { tone: "dim", text: "  openai" },
   { tone: "code", text: "    tts-1" },
+  { tone: "code", text: "    gpt-4o-mini-tts" },
+  { tone: "dim", text: "" },
+  { tone: "dim", text: "Transcription models (4):" },
+  { tone: "dim", text: "" },
+  { tone: "dim", text: "  openai" },
   { tone: "code", text: "    whisper-1" },
-  { tone: "dim", text: "  speech" },
-  { tone: "code", text: "    text-to-speech models" },
-  { tone: "dim", text: "  transcription" },
-  { tone: "code", text: "    speech-to-text models" },
   { tone: "dim", text: "  ...and more" },
 ];
 

--- a/apps/web/components/landing/footer.tsx
+++ b/apps/web/components/landing/footer.tsx
@@ -8,7 +8,7 @@ export function Footer() {
               ai-cli
             </div>
             <div className="mt-3 text-sm text-white/40">
-              Generate text, images, and video from your terminal.
+              Generate text, images, video, and audio from your terminal.
             </div>
             <a
               href="https://vercel.com"
@@ -35,6 +35,7 @@ export function Footer() {
               <span>ai image &quot;prompt&quot;</span>
               <span>ai video &quot;prompt&quot;</span>
               <span>ai text &quot;prompt&quot;</span>
+              <span>ai audio speak &quot;text&quot;</span>
               <span>ai models</span>
             </div>
           </div>

--- a/apps/web/components/landing/hero.tsx
+++ b/apps/web/components/landing/hero.tsx
@@ -19,9 +19,9 @@ export function Hero() {
             className="landing-fade-up mt-5 text-base text-[#888] leading-relaxed"
             style={{ animationDelay: "90ms" }}
           >
-            A tiny CLI for generating text, images, and video with dead-simple
-            commands. Pipe content in and out. Compare models side by side. See
-            results inline.
+            A tiny CLI for generating text, images, video, and audio with
+            dead-simple commands. Pipe content in and out. Compare models side
+            by side. See results inline.
           </p>
         </div>
 

--- a/apps/web/components/landing/terminal.tsx
+++ b/apps/web/components/landing/terminal.tsx
@@ -35,7 +35,7 @@ const scenes: readonly scene[] = [
       { tone: "dim", text: "Generating image with openai/gpt-image-2" },
       { tone: "ok", text: "Generating video with bytedance/seedance-2.0" },
       { tone: "plain", text: "" },
-      { tone: "ok", text: "Saved to /Users/you/output.mp4 (12.4s)" },
+      { tone: "ok", text: "Saved to /Users/you/resp_video.mp4 (12.4s)" },
     ],
   },
   {
@@ -51,7 +51,21 @@ const scenes: readonly scene[] = [
       { tone: "plain", text: "  2. Adds token expiry validation" },
       { tone: "plain", text: "  3. Removes deprecated OAuth1 flow" },
       { tone: "plain", text: "" },
-      { tone: "ok", text: "Saved to /Users/you/output.md" },
+      { tone: "ok", text: "Saved to /Users/you/resp_text.md" },
+    ],
+  },
+  {
+    name: "audio",
+    data: [
+      { tone: "input", text: '$ ai audio speak "Thanks for trying ai-cli"' },
+      { tone: "dim", text: "" },
+      { tone: "dim", text: "Generating audio with openai/tts-1" },
+      { tone: "plain", text: "" },
+      { tone: "ok", text: "Saved to /Users/you/resp_8j3k2m1n.mp3 (1.8s)" },
+      { tone: "muted", text: "Playing audio  ▁▂▃▅▇▆▄▃▂▁" },
+      { tone: "plain", text: "" },
+      { tone: "input", text: "$ ai audio transcribe meeting.mp3" },
+      { tone: "ok", text: "Saved to /Users/you/transcript.txt" },
     ],
   },
 ];

--- a/apps/web/components/landing/terminal.tsx
+++ b/apps/web/components/landing/terminal.tsx
@@ -65,7 +65,7 @@ const scenes: readonly scene[] = [
       { tone: "muted", text: "Playing audio  ▁▂▃▅▇▆▄▃▂▁" },
       { tone: "plain", text: "" },
       { tone: "input", text: "$ ai audio transcribe meeting.mp3" },
-      { tone: "ok", text: "Saved to /Users/you/transcript.txt" },
+      { tone: "ok", text: "Saved to /Users/you/resp_transcript.txt" },
     ],
   },
 ];

--- a/apps/web/components/landing/terminal.tsx
+++ b/apps/web/components/landing/terminal.tsx
@@ -23,8 +23,8 @@ const scenes: readonly scene[] = [
         text: '$ ai image "a sunset" -m "openai/gpt-image-2,bfl/flux-2-pro"',
       },
       { tone: "plain", text: "" },
-      { tone: "ok", text: "Saved to /Users/you/output-1.png (3.2s)" },
-      { tone: "ok", text: "Saved to /Users/you/output-2.png (4.1s)" },
+      { tone: "ok", text: "Saved to /Users/you/resp_img_a-1.png (3.2s)" },
+      { tone: "ok", text: "Saved to /Users/you/resp_img_b-2.png (4.1s)" },
     ],
   },
   {

--- a/apps/web/docs/commands.mdx
+++ b/apps/web/docs/commands.mdx
@@ -142,6 +142,103 @@ ai text "summarize this" < notes.txt
 
 ---
 
+## audio
+
+Generate speech from text or transcribe audio to text.
+
+```bash
+ai audio speak "Hello from AI Gateway"
+ai audio transcribe recording.mp3
+cat voice-note.mp3 | ai audio transcribe -o transcript.txt
+```
+
+### audio speak
+
+<Properties>
+  <Property name="-m, --model" type="string">
+    Speech model ID. Comma-separated for multi-model.
+  </Property>
+  <Property name="-o, --output" type="path">
+    Output file path or directory.
+  </Property>
+  <Property name="-f, --format" type="string" default="mp3">
+    Audio output format.
+  </Property>
+  <Property name="--voice" type="string">
+    Voice to use for speech generation.
+  </Property>
+  <Property name="--instructions" type="string">
+    Instructions for speech generation.
+  </Property>
+  <Property name="--speed" type="number">
+    Speech speed.
+  </Property>
+  <Property name="--language" type="code">
+    Language code, such as `en` or `fr`, or `auto`.
+  </Property>
+  <Property name="-n, --count" type="number" default="1">
+    Number of generations per model.
+  </Property>
+  <Property name="-p, --concurrency" type="number" default="4">
+    Max parallel generations.
+  </Property>
+  <Property name="-q, --quiet" type="boolean">
+    Suppress progress output.
+  </Property>
+  <Property name="--json" type="boolean">
+    Output metadata as JSON.
+  </Property>
+  <Property name="--no-play" type="boolean">
+    Disable audio playback after generation.
+  </Property>
+  <Property name="--no-waveform" type="boolean">
+    Disable accurate terminal waveform preview.
+  </Property>
+</Properties>
+
+`audio speak` accepts text from an argument or stdin:
+
+```bash
+echo "Ship the changelog" | ai audio speak -o changelog.mp3
+cat announcement.txt | ai audio speak --format wav -o announcement.wav
+```
+
+### audio transcribe
+
+<Properties>
+  <Property name="-m, --model" type="string">
+    Transcription model ID. Comma-separated for multi-model.
+  </Property>
+  <Property name="-o, --output" type="path">
+    Output file path or directory.
+  </Property>
+  <Property name="-f, --format" type="md | txt" default="txt">
+    Transcript output format.
+  </Property>
+  <Property name="-n, --count" type="number" default="1">
+    Number of transcriptions per model.
+  </Property>
+  <Property name="-p, --concurrency" type="number" default="4">
+    Max parallel transcriptions.
+  </Property>
+  <Property name="-q, --quiet" type="boolean">
+    Suppress progress output.
+  </Property>
+  <Property name="--json" type="boolean">
+    Output metadata as JSON.
+  </Property>
+</Properties>
+
+`audio transcribe` accepts a local path, `file://` URL, `http(s)://` URL, or piped audio:
+
+```bash
+ai audio transcribe meeting.mp3
+ai audio transcribe https://example.com/call.wav
+cat recording.mp3 | ai audio transcribe
+```
+
+---
+
 ## models
 
 List available models from the AI Gateway.
@@ -155,7 +252,7 @@ ai models --creator openai --json
 ### Options
 
 <Properties>
-  <Property name="--type" type="text | image | video">
+  <Property name="--type" type="text | image | video | audio | speech | transcription">
     Filter by modality.
   </Property>
   <Property name="--creator" type="string">
@@ -177,10 +274,12 @@ Requests that exceed the per-command timeout are aborted automatically:
 | Command | Timeout |
 | --- | --- |
 | `text` | 120 seconds |
-| `image` | 120 seconds |
+| `image` | 300 seconds |
 | `video` | 300 seconds |
+| `audio speak` | 120 seconds |
+| `audio transcribe` | 120 seconds |
 
-Video generation uses a longer timeout because models typically need more processing time.
+Image and video generation use a longer timeout because models typically need more processing time.
 
 ## Exit codes
 

--- a/apps/web/docs/configuration.mdx
+++ b/apps/web/docs/configuration.mdx
@@ -24,6 +24,12 @@ ai-cli is configured entirely through environment variables. There is no config 
   <Property name="AI_CLI_VIDEO_MODEL" type="string">
     Default video model. Overrides `bytedance/seedance-2.0`.
   </Property>
+  <Property name="AI_CLI_SPEECH_MODEL" type="string">
+    Default speech model. Overrides `openai/tts-1`.
+  </Property>
+  <Property name="AI_CLI_TRANSCRIPTION_MODEL" type="string">
+    Default transcription model. Overrides `openai/whisper-1`.
+  </Property>
   <Property name="AI_CLI_OUTPUT_DIR" type="path">
     Default output directory for generated files.
   </Property>
@@ -50,5 +56,6 @@ ai-cli is configured entirely through environment variables. There is no config 
 export AI_GATEWAY_API_KEY="gw_..."
 export AI_CLI_TEXT_MODEL="anthropic/claude-sonnet-4"
 export AI_CLI_IMAGE_MODEL="bfl/flux-2-pro"
+export AI_CLI_SPEECH_MODEL="openai/tts-1"
 export AI_CLI_OUTPUT_DIR="$HOME/ai-output"
 ```

--- a/apps/web/docs/images.mdx
+++ b/apps/web/docs/images.mdx
@@ -53,17 +53,19 @@ ai audio speak "hello" --no-play
 ai audio speak "hello" --no-waveform
 ```
 
-Force preview on in terminals that aren't auto-detected:
+Force image and video preview on in terminals that aren't auto-detected:
 
 ```bash
 export AI_CLI_PREVIEW=1
 ```
 
-Force preview off globally:
+Disable image and video preview globally:
 
 ```bash
 export AI_CLI_PREVIEW=0
 ```
+
+`AI_CLI_PREVIEW` controls visual previews only. Use `--no-play`, `--no-waveform`, `--quiet`, or `--json` to disable audio playback and waveform previews.
 
 <Callout type="tip">
   When multiple images or audio files are generated (via `-n` or multi-model), previews are batched and displayed after all generations complete.

--- a/apps/web/docs/images.mdx
+++ b/apps/web/docs/images.mdx
@@ -1,12 +1,12 @@
 ---
 title: Inline Preview
-description: See generated images and video frames directly in your terminal.
+description: See generated images, video frames, and speech previews directly in your terminal.
 order: 7
 ---
 
 ## How it works
 
-When running in a terminal that supports the [Kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/), generated images and video frames are displayed inline automatically.
+When running in a terminal that supports the [Kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/), generated images and video frames are displayed inline automatically. Generated speech can also play back in interactive terminals with an accurate waveform preview.
 
 ## Supported terminals
 
@@ -34,6 +34,14 @@ Video previews extract and decode an H.264 keyframe from the midpoint of the gen
 ai video "ocean waves"
 ```
 
+## Audio preview
+
+`audio speak` plays generated speech after saving it and renders a waveform from decoded audio samples. WAV output is decoded directly; MP3 and other encoded formats use a local decoder when available (`ffmpeg`, `mpg123`, `sox`, or `afconvert`).
+
+```bash
+ai audio speak "Read this as a friendly update"
+```
+
 ## Controlling preview
 
 Disable inline preview for a single command:
@@ -41,6 +49,8 @@ Disable inline preview for a single command:
 ```bash
 ai image "a sunset" --no-preview
 ai video "a sunset" --no-preview
+ai audio speak "hello" --no-play
+ai audio speak "hello" --no-waveform
 ```
 
 Force preview on in terminals that aren't auto-detected:
@@ -56,5 +66,5 @@ export AI_CLI_PREVIEW=0
 ```
 
 <Callout type="tip">
-  When multiple images are generated (via `-n` or multi-model), previews are batched and displayed after all generations complete.
+  When multiple images or audio files are generated (via `-n` or multi-model), previews are batched and displayed after all generations complete.
 </Callout>

--- a/apps/web/docs/index.mdx
+++ b/apps/web/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Introduction
-description: Generate text, images, and video from the terminal.
+description: Generate text, images, video, and audio from the terminal.
 order: 1
 ---
 
-ai-cli is a tiny, agent-native CLI for generating text, images, and video with dead-simple commands. It uses the [Vercel AI SDK](https://sdk.vercel.ai) and [AI Gateway](https://vercel.com/docs/ai-gateway) for unified access to hundreds of models.
+ai-cli is a tiny, agent-native CLI for generating text, images, video, and audio with dead-simple commands. It uses the [Vercel AI SDK](https://sdk.vercel.ai) and [AI Gateway](https://vercel.com/docs/ai-gateway) for unified access to hundreds of models.
 
 ## What it does
 
@@ -12,9 +12,10 @@ ai-cli is a tiny, agent-native CLI for generating text, images, and video with d
   <Card title="Image generation" description="Create images from text or existing images." />
   <Card title="Video generation" description="Generate video from text or images." />
   <Card title="Text generation" description="Generate text from prompts with any language model." />
+  <Card title="Audio generation" description="Generate speech or transcribe audio files and streams." />
   <Card title="Multi-model comparison" description="Run the same prompt across multiple models in parallel." />
   <Card title="Stdin piping" description="Pipe any content in and out for composable workflows." />
-  <Card title="Inline preview" description="See generated images and video frames directly in your terminal." />
+  <Card title="Inline preview" description="See generated images, video frames, and speech playback directly in your terminal." />
 </Cards>
 
 ## Quick start
@@ -41,6 +42,8 @@ ai-cli is a tiny, agent-native CLI for generating text, images, and video with d
     ai image "a cute dog"
     ai video "a spinning triangle"
     ai text "explain quantum computing"
+    ai audio speak "Thanks for trying ai-cli"
+    ai audio transcribe recording.mp3
     ```
   </Step>
 </Steps>
@@ -51,6 +54,7 @@ ai-cli is a tiny, agent-native CLI for generating text, images, and video with d
   <Card title="image" description="Generate images from a prompt." href="/docs/commands#image" />
   <Card title="video" description="Generate video from a prompt or image." href="/docs/commands#video" />
   <Card title="text" description="Generate text from a prompt." href="/docs/commands#text" />
+  <Card title="audio" description="Generate speech or transcribe audio." href="/docs/commands#audio" />
   <Card title="models" description="List available models from the gateway." href="/docs/commands#models" />
 </Cards>
 

--- a/apps/web/docs/models.mdx
+++ b/apps/web/docs/models.mdx
@@ -50,7 +50,7 @@ Combine with `-n` to generate multiple per model:
 ai image "a sunset" -n 2 -m "openai/gpt-image-1,bfl/flux-2-pro"
 ```
 
-This produces 4 images total (2 per model), saved as `output-1.png` through `output-4.png`.
+This produces 4 images total (2 per model), saved with generated filename stems and numeric suffixes, such as `resp_abc-1.png` through `resp_def-4.png`.
 
 ## Listing models
 

--- a/apps/web/docs/models.mdx
+++ b/apps/web/docs/models.mdx
@@ -13,6 +13,8 @@ Each command type has a default model used when `-m` is not specified:
 | text | `openai/gpt-5.5` | `AI_CLI_TEXT_MODEL` |
 | image | `openai/gpt-image-2` | `AI_CLI_IMAGE_MODEL` |
 | video | `bytedance/seedance-2.0` | `AI_CLI_VIDEO_MODEL` |
+| speech | `openai/tts-1` | `AI_CLI_SPEECH_MODEL` |
+| transcription | `openai/whisper-1` | `AI_CLI_TRANSCRIPTION_MODEL` |
 
 The `-m` flag always takes priority over environment variables.
 
@@ -23,6 +25,7 @@ Use `creator/model-name` format:
 ```bash
 ai text -m "anthropic/claude-sonnet-4" "hello"
 ai image -m "bfl/flux-2-pro" "a sunset"
+ai audio speak -m "openai/tts-1" "hello"
 ```
 
 Short names (without the creator prefix) are resolved against models fetched from the gateway:
@@ -30,6 +33,7 @@ Short names (without the creator prefix) are resolved against models fetched fro
 ```bash
 ai text -m gpt-5.5 "hello"
 ai image -m flux-2-pro "a sunset"
+ai audio speak -m tts-1 "hello"
 ```
 
 ## Multi-model comparison
@@ -53,6 +57,7 @@ This produces 4 images total (2 per model), saved as `output-1.png` through `out
 ```bash
 ai models                          # all models
 ai models --type image             # image models only
+ai models --type audio             # speech and transcription models
 ai models --creator google         # Google models only
 ai models --json                   # JSON with descriptions
 ```
@@ -64,7 +69,7 @@ In human mode, models are grouped by creator and display short names. Use `--jso
 All models are accessed through [Vercel AI Gateway](https://vercel.com/docs/ai-gateway):
 
 <Cards>
-  <Card title="OpenAI" description="GPT-5.5, GPT-4.1, GPT Image 2, o3, o4-mini" />
+  <Card title="OpenAI" description="GPT-5.5, GPT-4.1, GPT Image 2, TTS, Whisper" />
   <Card title="Anthropic" description="Claude Sonnet 4" />
   <Card title="Google" description="Gemini 2.5 Pro, Imagen 4, Veo 3" />
   <Card title="xAI" description="Grok 3, Grok Imagine" />

--- a/apps/web/docs/single.mdx
+++ b/apps/web/docs/single.mdx
@@ -6,7 +6,7 @@ order: 6
 
 ## Stdin
 
-All generation commands accept input via stdin. The behavior depends on the command type:
+Most commands accept input via stdin. The behavior depends on the command type:
 
 ### Text
 
@@ -47,6 +47,15 @@ ai image "a dragon" | ai video "animate this"
 cat scene.png | ai video "zoom out slowly"
 ```
 
+### Audio
+
+`audio speak` reads stdin as text. `audio transcribe` reads stdin as binary audio:
+
+```bash
+echo "Ship the changelog" | ai audio speak -o changelog.mp3
+cat recording.mp3 | ai audio transcribe -o transcript.txt
+```
+
 ## Stdout
 
 Output behavior changes based on whether stdout is a TTY (interactive terminal) or a pipe:
@@ -56,9 +65,10 @@ Output behavior changes based on whether stdout is a TTY (interactive terminal) 
 Saves to a file and prints the path to stderr:
 
 ```bash
-ai text "hello"         # → saves output.md, prints "Saved to /path/output.md"
-ai image "a cat"        # → saves output.png
-ai video "ocean"        # → saves output.mp4
+ai text "hello"         # → saves <id>.md, prints "Saved to /path/<id>.md"
+ai image "a cat"        # → saves <id>.png
+ai video "ocean"        # → saves <id>.mp4
+ai audio speak "hello"  # → saves <id>.mp3
 ```
 
 ### Piped (non-TTY)
@@ -69,6 +79,7 @@ Writes raw output directly to stdout for composability:
 ai text "hello" | pbcopy                    # copy to clipboard
 ai image "a dragon" | ai video "animate"    # chain image → video
 ai text "hello" > response.md              # redirect to file
+ai audio speak "hello" > speech.mp3        # redirect audio bytes
 ```
 
 ## Output path
@@ -78,15 +89,16 @@ Control where files are saved with `-o`:
 ```bash
 ai image "a sunset" -o sunset.png          # specific file
 ai image "a sunset" -o ./renders/          # directory (auto-names files)
+ai audio transcribe call.mp3 -o call.txt   # transcript file
 ```
 
-When `-o` points to a directory, files are named `output.png`, `output-2.png`, etc.
+When `-o` points to a directory, files use response IDs when available and random 8-character names otherwise.
 
 The `AI_CLI_OUTPUT_DIR` environment variable sets a default output directory:
 
 ```bash
 export AI_CLI_OUTPUT_DIR=~/ai-output
-ai image "a sunset"    # → saves to ~/ai-output/output.png
+ai image "a sunset"    # → saves to ~/ai-output/<id>.png
 ```
 
 ## JSON metadata
@@ -107,7 +119,7 @@ ai image "a sunset" --json
       "model": "openai/gpt-image-2",
       "elapsed_ms": 3420,
       "success": true,
-      "file": "/Users/you/output.png"
+      "file": "/Users/you/resp_abc123.png"
     }
   ]
 }

--- a/apps/web/docs/troubleshooting.mdx
+++ b/apps/web/docs/troubleshooting.mdx
@@ -26,8 +26,10 @@ Requests are aborted if they exceed the per-command timeout:
 | Command | Timeout |
 | --- | --- |
 | `text` | 120 seconds |
-| `image` | 120 seconds |
+| `image` | 300 seconds |
 | `video` | 300 seconds |
+| `audio speak` | 120 seconds |
+| `audio transcribe` | 120 seconds |
 
 If you're consistently hitting timeouts, try a faster model variant (e.g. `bytedance/seedance-2.0-fast` instead of `bytedance/seedance-2.0`).
 

--- a/apps/web/fromsrc.config.ts
+++ b/apps/web/fromsrc.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "fromsrc";
 
 export default defineConfig({
   title: "ai-cli",
-  description: "Generate text, images, and video from the terminal.",
+  description: "Generate text, images, video, and audio from the terminal.",
   docsDir: "docs",
   theme: "dark",
   sidebar: {

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "packages/ai-cli": {
       "name": "ai-cli",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "bin": {
         "ai": "./dist/index.js",
       },

--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -185,7 +185,7 @@ ai image "a sunset" -n 2 -m "openai/gpt-image-1,bfl/flux-2-pro"   # 4 images tot
 
 ### Inline Preview
 
-When running in a terminal that supports the [Kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/) (Kitty, Ghostty, WezTerm, Warp, iTerm2), generated images and videos are displayed inline automatically. Video previews decode an H.264 keyframe from the midpoint of the video using [openh264](https://github.com/cisco/openh264) compiled to WebAssembly — no native dependencies required. Use `--no-preview` to disable this, or set `AI_CLI_PREVIEW=1` to force it on in undetected terminals.
+When running in a terminal that supports the [Kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/) (Kitty, Ghostty, WezTerm, Warp, iTerm2), generated images and videos are displayed inline automatically. Video previews decode an H.264 keyframe from the midpoint of the video using [openh264](https://github.com/cisco/openh264) compiled to WebAssembly — no native dependencies required. `audio speak` can also play generated speech and render a terminal waveform after saving. Use `--no-preview` for image/video previews, `--no-play` or `--no-waveform` for audio previews, or set `AI_CLI_PREVIEW=1` to force visual previews on in undetected terminals.
 
 ### Output Behavior
 
@@ -222,7 +222,7 @@ Requests that exceed the timeout are aborted automatically:
 | Command | Timeout |
 |---|---|
 | `text` | 120 seconds |
-| `image` | 120 seconds |
+| `image` | 300 seconds |
 | `video` | 300 seconds |
 | `audio speak` | 120 seconds |
 | `audio transcribe` | 120 seconds |

--- a/packages/ai-cli/package.json
+++ b/packages/ai-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-cli",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A tiny, agent-native CLI for generating images, video, audio and text with dead-simple commands, stdin support and predictable artifact outputs",
   "type": "module",
   "license": "Apache-2.0",

--- a/skills/ai-cli/SKILL.md
+++ b/skills/ai-cli/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ai-cli
-description: Generate text, images, and video from the terminal using AI models.
+description: Generate text, images, video, and audio from the terminal using AI models.
 ---
 
 # ai-cli
 
-Generate text, images, and video from the terminal using AI models.
+Generate text, images, video, and audio from the terminal using AI models.
 
 ## When to Use
 
@@ -13,6 +13,7 @@ Use when you need to:
 - Generate images from text prompts or existing images
 - Generate video from text prompts or images
 - Generate text (summaries, explanations, code reviews) from prompts or piped content
+- Generate speech from text or transcribe audio files and streams
 - Compare outputs across multiple models side-by-side
 - Build composable media pipelines by chaining commands via stdin/stdout
 
@@ -26,7 +27,9 @@ Requires `AI_GATEWAY_API_KEY` or a provider-specific key (e.g. `OPENAI_API_KEY`)
 ai text "explain this code"              # generate text
 ai image "a sunset over mountains"       # generate an image
 ai video "a spinning triangle"           # generate a video
-ai models --type image                   # list available models
+ai audio speak "hello"                   # generate speech
+ai audio transcribe recording.mp3        # transcribe audio
+ai models --type audio                   # list speech and transcription models
 ```
 
 ## Key Flags
@@ -53,6 +56,10 @@ ai image "a dragon" | ai video "animate this"
 
 # Image editing via stdin
 cat photo.png | ai image "make it a watercolor"
+
+# Audio workflows
+echo "Ship the changelog" | ai audio speak -o changelog.mp3
+cat recording.mp3 | ai audio transcribe -o transcript.txt
 ```
 
 ## Structured Output
@@ -74,7 +81,7 @@ Returns:
       "model": "openai/gpt-image-2",
       "elapsed_ms": 3420,
       "success": true,
-      "file": "/path/to/output.png"
+      "file": "/path/to/resp_abc123.png"
     }
   ]
 }
@@ -92,12 +99,17 @@ ai image "a sunset" -m "openai/gpt-image-1,bfl/flux-2-pro,xai/grok-imagine-image
 - **Piped (non-TTY)**: writes raw content to stdout for chaining
 - **`-o <dir>`**: saves inside directory with auto-generated names
 
-**Important for agents**: Always use `-o` to save to a file when generating images or video. Without `-o` in a non-TTY context, raw binary data is written to stdout, which wastes context and is not useful for agents. Use `-o output.png` (or a directory) and read the file path from `--json` output instead.
+When the CLI chooses a filename, it uses a response ID when available and falls back to a random 8-character ID, such as `resp_abc123.png` or `7f3a9c1d.mp3`.
+
+**Important for agents**: Always use `-o` to save to a file when generating images, video, or speech audio. Without `-o` in a non-TTY context, raw binary data is written to stdout, which wastes context and is not useful for agents. Use `-o output.png`, `-o speech.mp3`, or an output directory and read the file path from `--json` output instead.
 
 ## Timeouts
 
-- text/image: 120 seconds
+- text: 120 seconds
+- image: 300 seconds
 - video: 300 seconds
+- audio speak: 120 seconds
+- audio transcribe: 120 seconds
 
 ## Exit Codes
 


### PR DESCRIPTION
- Bump ai-cli package metadata to v0.4.0.
- Add v0.4.0 release notes and audio coverage across README and website docs.
- Update contributor docs to require README, website, and changelog updates for user-facing changes.