### PR TITLE
docs: update website for audio commands

### DIFF
--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -31,7 +31,7 @@ const navigation = [
       },
       {
         type: "item" as const,
-        title: "Inline Preview",
+        title: "Terminal Previews",
         href: "/docs/images",
       },
     ],

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -6,19 +6,19 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "ai-cli",
-  description: "Generate text, images, and video from the terminal.",
+  description: "Generate text, images, video, and audio from the terminal.",
   openGraph: {
     type: "website",
     locale: "en_US",
     siteName: "ai-cli",
     title: "ai-cli",
-    description: "Generate text, images, and video from the terminal.",
+    description: "Generate text, images, video, and audio from the terminal.",
     images: [{ url: "/og", width: 1200, height: 630, alt: "ai-cli" }],
   },
   twitter: {
     card: "summary_large_image",
     title: "ai-cli",
-    description: "Generate text, images, and video from the terminal.",
+    description: "Generate text, images, video, and audio from the terminal.",
     images: ["/og"],
   },
 };

--- a/apps/web/components/landing/bento.tsx
+++ b/apps/web/components/landing/bento.tsx
@@ -7,8 +7,8 @@ interface item {
 const items: readonly item[] = [
   {
     id: "001",
-    title: "Inline preview",
-    body: "Generated images and video frames display directly in your terminal using the Kitty graphics protocol. Supports Kitty, Ghostty, WezTerm, Warp, and iTerm2.",
+    title: "Terminal previews",
+    body: "Generated images and video frames display directly in supported terminals. Speech output can play back after saving and render an accurate waveform preview.",
   },
   {
     id: "002",
@@ -88,7 +88,7 @@ export function Bento() {
             <div className="mt-6">
               <div className="inline-flex items-center gap-3 rounded-lg border border-white/10 bg-white/[0.03] px-4 py-2 font-mono text-sm text-white/60">
                 <span className="text-white/30">$</span>
-                <span>ai text &quot;hello&quot;</span>
+                <span>ai audio speak &quot;hello&quot;</span>
               </div>
             </div>
           </div>

--- a/apps/web/components/landing/features.tsx
+++ b/apps/web/components/landing/features.tsx
@@ -28,19 +28,21 @@ const pipingrows: readonly row[] = [
   { tone: "dim", text: "" },
   { tone: "cmd", text: '$ ai image "a dragon" | ai video "animate this"' },
   { tone: "code", text: "Saved to /Users/you/output.mp4" },
+  { tone: "dim", text: "" },
+  { tone: "cmd", text: '$ cat notes.txt | ai audio speak -o update.mp3' },
+  { tone: "code", text: "Saved to /Users/you/update.mp3" },
 ];
 
 const modelrows: readonly row[] = [
-  { tone: "cmd", text: "$ ai models --type image" },
+  { tone: "cmd", text: "$ ai models --type audio" },
   { tone: "dim", text: "" },
   { tone: "dim", text: "  openai" },
-  { tone: "code", text: "    gpt-image-2" },
-  { tone: "code", text: "    gpt-image-1" },
-  { tone: "dim", text: "  bfl" },
-  { tone: "code", text: "    flux-2-pro" },
-  { tone: "code", text: "    flux-kontext-pro" },
-  { tone: "dim", text: "  google" },
-  { tone: "code", text: "    imagen-4.0-generate-001" },
+  { tone: "code", text: "    tts-1" },
+  { tone: "code", text: "    whisper-1" },
+  { tone: "code", text: "    gpt-4o-transcribe" },
+  { tone: "dim", text: "  xai" },
+  { tone: "code", text: "    grok-tts" },
+  { tone: "code", text: "    grok-stt" },
   { tone: "dim", text: "  ...and more" },
 ];
 
@@ -141,11 +143,11 @@ export function Features() {
           <Spotlight
             tone="ash"
             title="Pipe everything."
-            description="Pipe text in as context, pipe images into video generation, chain commands together. Raw output on stdout when piped, file saves when interactive."
+            description="Pipe text in as context, pipe images into video generation, pipe text into speech, and transcribe audio from files or stdin. Raw output on stdout when piped, file saves when interactive."
             bullets={[
               "text stdin becomes prompt context",
-              "binary stdin for image-to-image and image-to-video",
-              "chain: ai image | ai video",
+              "binary stdin for image-to-image, image-to-video, and transcription",
+              "chain: ai image | ai video, text | ai audio speak",
             ]}
             flip
             window={<Panel rows={pipingrows} />}
@@ -154,7 +156,7 @@ export function Features() {
           <Spotlight
             tone="iron"
             title="Hundreds of models, one key."
-            description="Access text, image, and video models from OpenAI, Anthropic, Google, Black Forest Labs, ByteDance, and more through Vercel AI Gateway."
+            description="Access text, image, video, speech, and transcription models from OpenAI, Anthropic, Google, Black Forest Labs, ByteDance, xAI, and more through Vercel AI Gateway."
             bullets={[
               "short names resolve automatically: flux-2-pro, gpt-5.5",
               "live model listing from the gateway",

--- a/apps/web/components/landing/footer.tsx
+++ b/apps/web/components/landing/footer.tsx
@@ -8,7 +8,7 @@ export function Footer() {
               ai-cli
             </div>
             <div className="mt-3 text-sm text-white/40">
-              Generate text, images, and video from your terminal.
+              Generate text, images, video, and audio from your terminal.
             </div>
             <a
               href="https://vercel.com"
@@ -35,6 +35,7 @@ export function Footer() {
               <span>ai image &quot;prompt&quot;</span>
               <span>ai video &quot;prompt&quot;</span>
               <span>ai text &quot;prompt&quot;</span>
+              <span>ai audio speak &quot;prompt&quot;</span>
               <span>ai models</span>
             </div>
           </div>
@@ -46,7 +47,7 @@ export function Footer() {
             <div className="mt-4 flex flex-col gap-2 font-mono text-sm text-white/45">
               <span>multi-model comparison</span>
               <span>stdin/stdout piping</span>
-              <span>inline preview</span>
+              <span>terminal previews</span>
               <span>live model discovery</span>
             </div>
           </div>

--- a/apps/web/components/landing/hero.tsx
+++ b/apps/web/components/landing/hero.tsx
@@ -19,9 +19,9 @@ export function Hero() {
             className="landing-fade-up mt-5 text-base text-[#888] leading-relaxed"
             style={{ animationDelay: "90ms" }}
           >
-            A tiny CLI for generating text, images, and video with dead-simple
-            commands. Pipe content in and out. Compare models side by side. See
-            results inline.
+            A tiny CLI for generating text, images, video, and audio with
+            dead-simple commands. Pipe content in and out. Compare models side
+            by side. See results inline.
           </p>
         </div>
 

--- a/apps/web/components/landing/terminal.tsx
+++ b/apps/web/components/landing/terminal.tsx
@@ -54,6 +54,20 @@ const scenes: readonly scene[] = [
       { tone: "ok", text: "Saved to /Users/you/output.md" },
     ],
   },
+  {
+    name: "audio",
+    data: [
+      { tone: "input", text: '$ ai audio speak "Ship the changelog" -o changelog.mp3' },
+      { tone: "dim", text: "" },
+      { tone: "dim", text: "Generating audio with openai/tts-1" },
+      { tone: "ok", text: "Saved to /Users/you/changelog.mp3 (2.8s)" },
+      { tone: "plain", text: "" },
+      { tone: "plain", text: "__/--\\___/---\\__/--\\__" },
+      { tone: "plain", text: "" },
+      { tone: "input", text: "$ ai audio transcribe meeting.mp3" },
+      { tone: "ok", text: "Action items: update the release notes and publish the demo." },
+    ],
+  },
 ];
 
 function style(tone: tone): string {

--- a/apps/web/docs/commands.mdx
+++ b/apps/web/docs/commands.mdx
@@ -142,6 +142,92 @@ ai text "summarize this" < notes.txt
 
 ---
 
+## audio
+
+Generate speech from text or transcribe audio to text.
+
+```bash
+ai audio speak "Hello from AI Gateway"
+ai audio transcribe recording.mp3
+cat voice-note.mp3 | ai audio transcribe
+```
+
+### `audio speak`
+
+<Properties>
+  <Property name="-m, --model" type="string">
+    Speech model ID. Comma-separated for multi-model.
+  </Property>
+  <Property name="-o, --output" type="path">
+    Output file path or directory.
+  </Property>
+  <Property name="-f, --format" type="audio format" default="mp3">
+    Audio output format. Known formats include `mp3`, `wav`, `opus`, `aac`, `flac`, and `pcm`.
+  </Property>
+  <Property name="--voice" type="string">
+    Voice to use for speech generation.
+  </Property>
+  <Property name="--instructions" type="string">
+    Instructions for speech generation.
+  </Property>
+  <Property name="--speed" type="number">
+    Speech speed.
+  </Property>
+  <Property name="--language" type="string">
+    Language code, such as `en`, `fr`, or `auto`.
+  </Property>
+  <Property name="-n, --count" type="number" default="1">
+    Number of generations per model.
+  </Property>
+  <Property name="-p, --concurrency" type="number" default="4">
+    Max parallel generations.
+  </Property>
+  <Property name="--no-play" type="boolean">
+    Disable audio playback after generation.
+  </Property>
+  <Property name="--no-waveform" type="boolean">
+    Disable accurate terminal waveform preview.
+  </Property>
+  <Property name="-q, --quiet" type="boolean">
+    Suppress progress output.
+  </Property>
+  <Property name="--json" type="boolean">
+    Output metadata as JSON.
+  </Property>
+</Properties>
+
+`audio speak` accepts text from an argument or stdin. In interactive terminals, it saves the audio file, plays it back, and renders a waveform preview when possible.
+
+### `audio transcribe`
+
+<Properties>
+  <Property name="-m, --model" type="string">
+    Transcription model ID. Comma-separated for multi-model.
+  </Property>
+  <Property name="-o, --output" type="path">
+    Output file path or directory.
+  </Property>
+  <Property name="-f, --format" type="md | txt" default="txt">
+    Transcript output format.
+  </Property>
+  <Property name="-n, --count" type="number" default="1">
+    Number of transcriptions per model.
+  </Property>
+  <Property name="-p, --concurrency" type="number" default="4">
+    Max parallel transcriptions.
+  </Property>
+  <Property name="-q, --quiet" type="boolean">
+    Suppress progress output.
+  </Property>
+  <Property name="--json" type="boolean">
+    Output metadata as JSON.
+  </Property>
+</Properties>
+
+`audio transcribe` accepts a local path, `file://` URL, `http(s)://` URL, or piped audio.
+
+---
+
 ## models
 
 List available models from the AI Gateway.
@@ -149,13 +235,14 @@ List available models from the AI Gateway.
 ```bash
 ai models
 ai models --type image
+ai models --type audio
 ai models --creator openai --json
 ```
 
 ### Options
 
 <Properties>
-  <Property name="--type" type="text | image | video">
+  <Property name="--type" type="text | image | video | audio | speech | transcription">
     Filter by modality.
   </Property>
   <Property name="--creator" type="string">
@@ -179,6 +266,8 @@ Requests that exceed the per-command timeout are aborted automatically:
 | `text` | 120 seconds |
 | `image` | 120 seconds |
 | `video` | 300 seconds |
+| `audio speak` | 120 seconds |
+| `audio transcribe` | 120 seconds |
 
 Video generation uses a longer timeout because models typically need more processing time.
 

--- a/apps/web/docs/configuration.mdx
+++ b/apps/web/docs/configuration.mdx
@@ -24,11 +24,17 @@ ai-cli is configured entirely through environment variables. There is no config 
   <Property name="AI_CLI_VIDEO_MODEL" type="string">
     Default video model. Overrides `bytedance/seedance-2.0`.
   </Property>
+  <Property name="AI_CLI_SPEECH_MODEL" type="string">
+    Default speech model. Overrides `openai/tts-1`.
+  </Property>
+  <Property name="AI_CLI_TRANSCRIPTION_MODEL" type="string">
+    Default transcription model. Overrides `openai/whisper-1`.
+  </Property>
   <Property name="AI_CLI_OUTPUT_DIR" type="path">
     Default output directory for generated files.
   </Property>
   <Property name="AI_CLI_PREVIEW" type="0 | 1">
-    `1` forces inline preview on, `0` disables it.
+    `1` forces image/video terminal preview on, `0` disables it.
   </Property>
   <Property name="NO_COLOR" type="any">
     Disable ANSI color output.
@@ -50,5 +56,6 @@ ai-cli is configured entirely through environment variables. There is no config 
 export AI_GATEWAY_API_KEY="gw_..."
 export AI_CLI_TEXT_MODEL="anthropic/claude-sonnet-4"
 export AI_CLI_IMAGE_MODEL="bfl/flux-2-pro"
+export AI_CLI_SPEECH_MODEL="openai/tts-1"
 export AI_CLI_OUTPUT_DIR="$HOME/ai-output"
 ```

--- a/apps/web/docs/images.mdx
+++ b/apps/web/docs/images.mdx
@@ -1,12 +1,12 @@
 ---
-title: Inline Preview
-description: See generated images and video frames directly in your terminal.
+title: Terminal Previews
+description: See generated media previews directly in your terminal.
 order: 7
 ---
 
 ## How it works
 
-When running in a terminal that supports the [Kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/), generated images and video frames are displayed inline automatically.
+When running in a terminal that supports the [Kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/), generated images and video frames are displayed inline automatically. Speech output can also play back after saving and render a waveform preview when audio samples can be decoded locally.
 
 ## Supported terminals
 
@@ -34,13 +34,28 @@ Video previews extract and decode an H.264 keyframe from the midpoint of the gen
 ai video "ocean waves"
 ```
 
+## Audio preview
+
+Speech output is saved to disk, then played back in interactive terminals. WAV output is decoded directly; MP3 and other encoded formats use a local decoder when available (`ffmpeg`, `mpg123`, `sox`, or `afconvert`) to render a waveform.
+
+```bash
+ai audio speak "Read this as a product update"
+```
+
 ## Controlling preview
 
-Disable inline preview for a single command:
+Disable image or video preview for a single command:
 
 ```bash
 ai image "a sunset" --no-preview
 ai video "a sunset" --no-preview
+```
+
+Disable audio playback or waveform previews:
+
+```bash
+ai audio speak "hello" --no-play
+ai audio speak "hello" --no-waveform
 ```
 
 Force preview on in terminals that aren't auto-detected:
@@ -56,5 +71,5 @@ export AI_CLI_PREVIEW=0
 ```
 
 <Callout type="tip">
-  When multiple images are generated (via `-n` or multi-model), previews are batched and displayed after all generations complete.
+  When multiple media outputs are generated via `-n` or multi-model, previews are batched and displayed after all generations complete.
 </Callout>

--- a/apps/web/docs/index.mdx
+++ b/apps/web/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Introduction
-description: Generate text, images, and video from the terminal.
+description: Generate text, images, video, and audio from the terminal.
 order: 1
 ---
 
-ai-cli is a tiny, agent-native CLI for generating text, images, and video with dead-simple commands. It uses the [Vercel AI SDK](https://sdk.vercel.ai) and [AI Gateway](https://vercel.com/docs/ai-gateway) for unified access to hundreds of models.
+ai-cli is a tiny, agent-native CLI for generating text, images, video, and audio with dead-simple commands. It uses the [Vercel AI SDK](https://sdk.vercel.ai) and [AI Gateway](https://vercel.com/docs/ai-gateway) for unified access to hundreds of models.
 
 ## What it does
 
@@ -12,9 +12,10 @@ ai-cli is a tiny, agent-native CLI for generating text, images, and video with d
   <Card title="Image generation" description="Create images from text or existing images." />
   <Card title="Video generation" description="Generate video from text or images." />
   <Card title="Text generation" description="Generate text from prompts with any language model." />
+  <Card title="Audio generation" description="Generate speech from text and transcribe audio files." />
   <Card title="Multi-model comparison" description="Run the same prompt across multiple models in parallel." />
   <Card title="Stdin piping" description="Pipe any content in and out for composable workflows." />
-  <Card title="Inline preview" description="See generated images and video frames directly in your terminal." />
+  <Card title="Terminal previews" description="See generated media previews directly in your terminal." />
 </Cards>
 
 ## Quick start
@@ -41,6 +42,8 @@ ai-cli is a tiny, agent-native CLI for generating text, images, and video with d
     ai image "a cute dog"
     ai video "a spinning triangle"
     ai text "explain quantum computing"
+    ai audio speak "Thanks for trying ai-cli"
+    ai audio transcribe recording.mp3
     ```
   </Step>
 </Steps>
@@ -51,6 +54,7 @@ ai-cli is a tiny, agent-native CLI for generating text, images, and video with d
   <Card title="image" description="Generate images from a prompt." href="/docs/commands#image" />
   <Card title="video" description="Generate video from a prompt or image." href="/docs/commands#video" />
   <Card title="text" description="Generate text from a prompt." href="/docs/commands#text" />
+  <Card title="audio" description="Generate speech and transcribe audio." href="/docs/commands#audio" />
   <Card title="models" description="List available models from the gateway." href="/docs/commands#models" />
 </Cards>
 

--- a/apps/web/docs/models.mdx
+++ b/apps/web/docs/models.mdx
@@ -13,6 +13,8 @@ Each command type has a default model used when `-m` is not specified:
 | text | `openai/gpt-5.5` | `AI_CLI_TEXT_MODEL` |
 | image | `openai/gpt-image-2` | `AI_CLI_IMAGE_MODEL` |
 | video | `bytedance/seedance-2.0` | `AI_CLI_VIDEO_MODEL` |
+| speech | `openai/tts-1` | `AI_CLI_SPEECH_MODEL` |
+| transcription | `openai/whisper-1` | `AI_CLI_TRANSCRIPTION_MODEL` |
 
 The `-m` flag always takes priority over environment variables.
 
@@ -23,6 +25,8 @@ Use `creator/model-name` format:
 ```bash
 ai text -m "anthropic/claude-sonnet-4" "hello"
 ai image -m "bfl/flux-2-pro" "a sunset"
+ai audio speak -m "openai/tts-1" "hello"
+ai audio transcribe -m "openai/whisper-1" recording.mp3
 ```
 
 Short names (without the creator prefix) are resolved against models fetched from the gateway:
@@ -30,6 +34,7 @@ Short names (without the creator prefix) are resolved against models fetched fro
 ```bash
 ai text -m gpt-5.5 "hello"
 ai image -m flux-2-pro "a sunset"
+ai audio speak -m tts-1 "hello"
 ```
 
 ## Multi-model comparison
@@ -53,6 +58,7 @@ This produces 4 images total (2 per model), saved as `output-1.png` through `out
 ```bash
 ai models                          # all models
 ai models --type image             # image models only
+ai models --type audio             # speech and transcription models
 ai models --creator google         # Google models only
 ai models --json                   # JSON with descriptions
 ```
@@ -64,10 +70,10 @@ In human mode, models are grouped by creator and display short names. Use `--jso
 All models are accessed through [Vercel AI Gateway](https://vercel.com/docs/ai-gateway):
 
 <Cards>
-  <Card title="OpenAI" description="GPT-5.5, GPT-4.1, GPT Image 2, o3, o4-mini" />
+  <Card title="OpenAI" description="GPT-5.5, GPT Image 2, TTS, Whisper, o3, o4-mini" />
   <Card title="Anthropic" description="Claude Sonnet 4" />
   <Card title="Google" description="Gemini 2.5 Pro, Imagen 4, Veo 3" />
-  <Card title="xAI" description="Grok 3, Grok Imagine" />
+  <Card title="xAI" description="Grok 3, Grok Imagine, speech and transcription" />
   <Card title="Meta" description="Llama 4 Maverick" />
   <Card title="Black Forest Labs" description="FLUX 2 Pro, FLUX Kontext" />
   <Card title="ByteDance" description="Seedance 2.0, Seedream 5.0" />

--- a/apps/web/docs/single.mdx
+++ b/apps/web/docs/single.mdx
@@ -47,6 +47,15 @@ ai image "a dragon" | ai video "animate this"
 cat scene.png | ai video "zoom out slowly"
 ```
 
+### Audio
+
+`audio speak` reads stdin as text for speech generation, while `audio transcribe` reads stdin as binary audio data:
+
+```bash
+cat announcement.txt | ai audio speak -o announcement.mp3
+cat voice-note.mp3 | ai audio transcribe
+```
+
 ## Stdout
 
 Output behavior changes based on whether stdout is a TTY (interactive terminal) or a pipe:
@@ -59,6 +68,7 @@ Saves to a file and prints the path to stderr:
 ai text "hello"         # → saves output.md, prints "Saved to /path/output.md"
 ai image "a cat"        # → saves output.png
 ai video "ocean"        # → saves output.mp4
+ai audio speak "hello"  # → saves output.mp3
 ```
 
 ### Piped (non-TTY)
@@ -69,6 +79,7 @@ Writes raw output directly to stdout for composability:
 ai text "hello" | pbcopy                    # copy to clipboard
 ai image "a dragon" | ai video "animate"    # chain image → video
 ai text "hello" > response.md              # redirect to file
+ai audio speak "hello" > hello.mp3         # redirect binary audio
 ```
 
 ## Output path
@@ -78,6 +89,7 @@ Control where files are saved with `-o`:
 ```bash
 ai image "a sunset" -o sunset.png          # specific file
 ai image "a sunset" -o ./renders/          # directory (auto-names files)
+ai audio transcribe meeting.mp3 -o notes.txt
 ```
 
 When `-o` points to a directory, files are named `output.png`, `output-2.png`, etc.
@@ -87,6 +99,7 @@ The `AI_CLI_OUTPUT_DIR` environment variable sets a default output directory:
 ```bash
 export AI_CLI_OUTPUT_DIR=~/ai-output
 ai image "a sunset"    # → saves to ~/ai-output/output.png
+ai audio speak "hi"    # → saves to ~/ai-output/output.mp3
 ```
 
 ## JSON metadata

--- a/apps/web/docs/troubleshooting.mdx
+++ b/apps/web/docs/troubleshooting.mdx
@@ -28,8 +28,14 @@ Requests are aborted if they exceed the per-command timeout:
 | `text` | 120 seconds |
 | `image` | 120 seconds |
 | `video` | 300 seconds |
+| `audio speak` | 120 seconds |
+| `audio transcribe` | 120 seconds |
 
 If you're consistently hitting timeouts, try a faster model variant (e.g. `bytedance/seedance-2.0-fast` instead of `bytedance/seedance-2.0`).
+
+## Audio preview does not play
+
+`ai audio speak` saves the generated file even when local playback or waveform decoding is unavailable. Use `--no-play` to skip playback, or install a local decoder such as `ffmpeg`, `mpg123`, `sox`, or `afconvert` for encoded audio waveform previews.
 
 ## `--quality` / `--style` warning
 

--- a/apps/web/fromsrc.config.ts
+++ b/apps/web/fromsrc.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "fromsrc";
 
 export default defineConfig({
   title: "ai-cli",
-  description: "Generate text, images, and video from the terminal.",
+  description: "Generate text, images, video, and audio from the terminal.",
   docsDir: "docs",
   theme: "dark",
   sidebar: {

--- a/apps/web/lib/page-titles.ts
+++ b/apps/web/lib/page-titles.ts
@@ -5,7 +5,7 @@ export const PAGE_TITLES: Record<string, string> = {
   models: "Models",
   configuration: "Configuration",
   single: "Piping & Output",
-  images: "Inline Preview",
+  images: "Terminal Previews",
 };
 
 export function getPageTitle(slug: string): string | null {


### PR DESCRIPTION
## Summary
- update the landing page copy, footer, feature examples, and terminal demo for audio commands
- add audio coverage to the web docs command reference, model defaults, configuration, piping/output, troubleshooting, and preview page
- update site metadata and docs nav labels from image/video-only language to include audio

## Tests
- bun run typecheck
- bun run --cwd apps/web build