### PR TITLE
fix: forward --aspect-ratio to google language-image models

### DIFF
--- a/packages/ai-cli/src/commands/image.test.ts
+++ b/packages/ai-cli/src/commands/image.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildLanguageImageProviderOptions } from "./image.js";
+
+describe("buildLanguageImageProviderOptions", () => {
+  test("returns undefined for non-google creators", () => {
+    expect(buildLanguageImageProviderOptions("openai", "16:9")).toBeUndefined();
+    expect(
+      buildLanguageImageProviderOptions(undefined, "16:9")
+    ).toBeUndefined();
+  });
+
+  test("sets image and text response modalities for google", () => {
+    expect(buildLanguageImageProviderOptions("google", undefined)).toEqual({
+      google: { responseModalities: ["IMAGE", "TEXT"] },
+    });
+  });
+
+  test("forwards aspect ratio via imageConfig when provided", () => {
+    expect(buildLanguageImageProviderOptions("google", "16:9")).toEqual({
+      google: {
+        responseModalities: ["IMAGE", "TEXT"],
+        imageConfig: { aspectRatio: "16:9" },
+      },
+    });
+  });
+});

--- a/packages/ai-cli/src/commands/image.ts
+++ b/packages/ai-cli/src/commands/image.ts
@@ -113,6 +113,15 @@ export function registerImageCommand(program: Command) {
         );
       }
 
+      if (
+        opts.size &&
+        models.some((m) => gatewayModels.languageImageModelIds.has(m))
+      ) {
+        process.stderr.write(
+          "Warning: --size is ignored for language-image models (e.g. gemini image models); use --aspect-ratio instead\n"
+        );
+      }
+
       const jobs = buildJobs(models, countPerModel);
 
       const { total, failed } = await runJobs(
@@ -154,10 +163,10 @@ export function registerImageCommand(program: Command) {
               model: gateway(modelId),
               messages: [{ role: "user", content: messageContent }],
               abortSignal: abort,
-              providerOptions:
-                creator === "google"
-                  ? { google: { responseModalities: ["IMAGE", "TEXT"] } }
-                  : undefined,
+              providerOptions: buildLanguageImageProviderOptions(
+                creator,
+                aspectRatio
+              ),
             });
             const imageFile = result.files?.find((f) =>
               f.mediaType.startsWith("image/")
@@ -207,6 +216,21 @@ export function registerImageCommand(program: Command) {
       if (failed === total) process.exit(1);
       if (failed > 0) process.exit(2);
     });
+}
+
+export function buildLanguageImageProviderOptions(
+  creator: string | undefined,
+  aspectRatio: `${number}:${number}` | undefined
+) {
+  if (creator !== "google") return undefined;
+  // Gemini image models don't support `size`; aspect ratio is passed via
+  // imageConfig.aspectRatio (defaults to 1:1 when unset).
+  return {
+    google: {
+      responseModalities: ["IMAGE", "TEXT"],
+      ...(aspectRatio ? { imageConfig: { aspectRatio } } : {}),
+    },
+  };
 }
 
 function buildProviderOptions(


### PR DESCRIPTION
Google language-image models (e.g. Gemini image models) were ignoring the `--aspect-ratio` option. This change forwards the aspect ratio via `imageConfig.aspectRatio` so users can control output dimensions.

## Changes

- Extract provider options construction into a new `buildLanguageImageProviderOptions` helper.
- Forward `--aspect-ratio` to Google models through `imageConfig.aspectRatio` (defaults to 1:1 when unset).
- Warn when `--size` is used with language-image models, since it is ignored; users should use `--aspect-ratio` instead.
- Add unit tests covering non-google creators, the default Google response modalities, and aspect ratio forwarding.

## Why

Previously there was no way to control the aspect ratio for Gemini image models, and `--size` (which these models don't support) silently had no effect. This makes the behavior explicit and gives users a working option.

Closes #61