### PR TITLE
fix: forward --aspect-ratio to Google language-image models

### DIFF
--- a/apps/web/docs/commands.mdx
+++ b/apps/web/docs/commands.mdx
@@ -29,7 +29,8 @@ ai image "edit this" < photo.png
     Max parallel generations.
   </Property>
   <Property name="--size" type="WxH">
-    Image size (e.g. `1024x1024`).
+    Image size (e.g. `1024x1024`). Not supported by Gemini image models — use
+    `--aspect-ratio` instead.
   </Property>
   <Property name="--aspect-ratio" type="W:H">
     Aspect ratio (e.g. `16:9`).

--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -78,6 +78,8 @@ cat input.png | ai image -i style.png "combine the subject with this style"
 
 Reference-image support is model-dependent; unsupported models may reject image inputs.
 
+Gemini image models (e.g. `google/gemini-2.5-flash-image`) don't support `--size`; use `--aspect-ratio` instead.
+
 ### video
 
 ```

--- a/packages/ai-cli/src/commands/image.test.ts
+++ b/packages/ai-cli/src/commands/image.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { languageImageProviderOptions } from "./image.js";
+
+describe("languageImageProviderOptions", () => {
+  test("returns undefined for non-google creators", () => {
+    expect(languageImageProviderOptions("openai")).toBeUndefined();
+    expect(languageImageProviderOptions("openai", "16:9")).toBeUndefined();
+    expect(languageImageProviderOptions(undefined, "16:9")).toBeUndefined();
+  });
+
+  test("requests image output for google models", () => {
+    expect(languageImageProviderOptions("google")).toEqual({
+      google: { responseModalities: ["IMAGE", "TEXT"] },
+    });
+  });
+
+  test("forwards aspect ratio via imageConfig for google models", () => {
+    expect(languageImageProviderOptions("google", "16:9")).toEqual({
+      google: {
+        responseModalities: ["IMAGE", "TEXT"],
+        imageConfig: { aspectRatio: "16:9" },
+      },
+    });
+  });
+});

--- a/packages/ai-cli/src/commands/image.ts
+++ b/packages/ai-cli/src/commands/image.ts
@@ -1,4 +1,4 @@
-import { generateImage, generateText, gateway } from "ai";
+import { generateImage, generateText, gateway, type JSONValue } from "ai";
 import type { Command } from "commander";
 
 import {
@@ -113,6 +113,15 @@ export function registerImageCommand(program: Command) {
         );
       }
 
+      if (
+        opts.size &&
+        models.some((m) => gatewayModels.languageImageModelIds.has(m))
+      ) {
+        process.stderr.write(
+          "Warning: --size is not supported by language image models; use --aspect-ratio instead\n"
+        );
+      }
+
       const jobs = buildJobs(models, countPerModel);
 
       const { total, failed } = await runJobs(
@@ -154,10 +163,10 @@ export function registerImageCommand(program: Command) {
               model: gateway(modelId),
               messages: [{ role: "user", content: messageContent }],
               abortSignal: abort,
-              providerOptions:
-                creator === "google"
-                  ? { google: { responseModalities: ["IMAGE", "TEXT"] } }
-                  : undefined,
+              providerOptions: languageImageProviderOptions(
+                creator,
+                aspectRatio
+              ),
             });
             const imageFile = result.files?.find((f) =>
               f.mediaType.startsWith("image/")
@@ -207,6 +216,21 @@ export function registerImageCommand(program: Command) {
       if (failed === total) process.exit(1);
       if (failed > 0) process.exit(2);
     });
+}
+
+export function languageImageProviderOptions(
+  creator: string | undefined,
+  aspectRatio?: `${number}:${number}`
+): { google: Record<string, JSONValue> } | undefined {
+  if (creator !== "google") return undefined;
+  return {
+    google: {
+      responseModalities: ["IMAGE", "TEXT"],
+      // Gemini image models don't support `size`; aspect ratio goes through
+      // imageConfig and defaults to 1:1 when unset.
+      ...(aspectRatio ? { imageConfig: { aspectRatio } } : {}),
+    },
+  };
 }
 
 function buildProviderOptions(


### PR DESCRIPTION
Previously, `--aspect-ratio` was silently ignored when generating images with Gemini language-image models (e.g. `google/gemini-2.5-flash-image`), which always defaulted to 1:1.

- Extracted provider-options logic into a new exported `languageImageProviderOptions()` helper that passes `aspectRatio` through Google's `imageConfig` alongside the existing `responseModalities` setting
- Added a stderr warning when `--size` is used with language image models, since Gemini image models don't support it — pointing users to `--aspect-ratio` instead
- Added unit tests covering non-Google creators, Google without aspect ratio, and Google with aspect ratio
- Updated CLI README and web docs to note that `--size` isn't supported by Gemini image models

Closes #61