### PR TITLE
Prepare v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.4.1
+
+<!-- release:start -->
+
+### Bug Fixes
+
+- **Aspect ratio for language-image models** - `--aspect-ratio` is now forwarded to Google language-image models like `google/gemini-2.5-flash-image`, which previously always generated 1:1 output; `--size` now warns when passed to these models instead of being silently ignored (#72)
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
 ## 0.4.0
 
 <!-- release:start -->

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "packages/ai-cli": {
       "name": "ai-cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "ai": "./dist/index.js",
       },

--- a/packages/ai-cli/package.json
+++ b/packages/ai-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A tiny, agent-native CLI for generating images, video, audio and text with dead-simple commands, stdin support and predictable artifact outputs",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Bumps `ai-cli` to v0.4.1 and updates the changelog for the patch release.

- Bumped version from `0.4.0` to `0.4.1` in `packages/ai-cli/package.json` and `bun.lock`
- Added a v0.4.1 changelog entry covering the aspect-ratio fix for Google language-image models (`--aspect-ratio` now forwarded, `--size` now warns instead of being silently ignored) (#72)