### PR TITLE
Add contributor guidance and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: Report broken or unexpected behavior.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please do not include API keys, tokens, credentials, private data, or other sensitive information.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened?
+      placeholder: Describe the broken or unexpected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Include exact steps, commands, inputs, or links where relevant.
+      placeholder: |
+        1. ...
+        2. See error ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What happened instead? Include logs or error output if useful.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: If relevant, include the package/app version, release, or commit SHA.
+      placeholder: "v0.0.0 or commit SHA"
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include relevant runtime, browser, device, or platform details.
+      placeholder: "Runtime, browser, device, or platform"
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      placeholder: Anything else that would help us investigate.
+  - type: dropdown
+    id: co_contributor_credit
+    attributes:
+      label: Co-contributor credit
+      description: If maintainers create and merge a pull request as a result of this issue, would you like to be listed as a co-contributor?
+      options:
+        - "Yes, credit my GitHub username"
+        - "No, do not credit me"
+      default: 0
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues for duplicates.
+          required: true
+        - label: I have removed API keys, tokens, credentials, and private data from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/change_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/change_proposal.yml
@@ -1,0 +1,63 @@
+name: Change proposal
+description: Propose a specific code or behavior change for maintainers to implement internally.
+title: "[Proposal]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when you have a concrete implementation idea that would otherwise have been a pull request. Pull requests are limited to collaborators; maintainers will review proposals and own any resulting PR.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What change are you proposing?
+      placeholder: Describe the proposed code or behavior change.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why should this change be made?
+      placeholder: Explain the bug, user need, or maintenance concern this addresses.
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Implementation notes
+      description: Share any technical details, affected files, API changes, or compatibility concerns.
+      placeholder: Include enough detail for maintainers to evaluate and implement the change internally.
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: Testing notes
+      description: How should maintainers validate this change?
+      placeholder: Suggested tests, commands, fixtures, or manual checks.
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks or tradeoffs
+      placeholder: Compatibility, behavior changes, security concerns, or migration risks.
+  - type: dropdown
+    id: co_contributor_credit
+    attributes:
+      label: Co-contributor credit
+      description: If maintainers create and merge a pull request as a result of this issue, would you like to be listed as a co-contributor?
+      options:
+        - "Yes, credit my GitHub username"
+        - "No, do not credit me"
+      default: 0
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues for duplicates.
+          required: true
+        - label: I understand pull requests are limited to collaborators and maintainers will handle implementation.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Feature request
+description: Suggest a new capability or change to existing behavior.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Pull requests are limited to collaborators; if this feature moves forward, a maintainer will own the implementation and pull request.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem would this solve?
+      placeholder: Describe the workflow, limitation, or user need.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What would you like this project to do?
+      placeholder: Describe the behavior, API, command shape, settings, or output you expect.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: Any workarounds or alternate designs you considered.
+  - type: textarea
+    id: examples
+    attributes:
+      label: Example usage
+      description: Optional examples, screenshots, commands, API calls, or expected output.
+      placeholder: |
+        Example input:
+        Expected output:
+  - type: dropdown
+    id: co_contributor_credit
+    attributes:
+      label: Co-contributor credit
+      description: If maintainers create and merge a pull request as a result of this issue, would you like to be listed as a co-contributor?
+      options:
+        - "Yes, credit my GitHub username"
+        - "No, do not credit me"
+      default: 0
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues for duplicates.
+          required: true
+        - label: I understand pull requests are limited to collaborators and maintainers will handle implementation.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+We welcome issues, bug reports, feature requests, and design feedback from the community.
+
+Pull requests are limited to collaborators. We keep implementation and merge ownership with collaborators so we can manage security review, roadmap fit, release timing, and maintenance responsibility consistently.
+
+If you have a proposed change, please open an issue instead of a pull request. Include:
+
+- The problem you are trying to solve
+- Relevant context or reproduction steps
+- Suggested behavior or implementation notes, if helpful
+
+Maintainers will review issues and handle code changes through the pull request process.
+
+Issue templates ask whether you would like to be listed as a co-contributor if a pull request is created and merged as a result of your issue.
+
+## Issues
+
+Before opening an issue, please search existing issues to avoid duplicates.
+
+Use the issue template that best matches your report:
+
+- **Bug report** for broken or unexpected behavior
+- **Feature request** for new capabilities or changes to existing behavior
+- **Change proposal** for implementation ideas that would otherwise have been a pull request
+
+Do not include API keys, tokens, credentials, private data, or other sensitive information in issues.


### PR DESCRIPTION
- Document collaborator-only pull request process
- Add reusable issue forms for bugs, features, and proposals
- Capture co-contributor credit preference for maintainer-owned PRs