### PR TITLE
Prepare v0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## Unreleased
+## 0.4.2
 
 <!-- release:start -->
 
 ### New Features
 
-- **Model info** - `ai models <model>` shows a detail card for any gateway model: context window, max output, pricing (input, output, cache read/write, web search), release date and per-provider latency, throughput and uptime; supports `--json`
+- **Model info** - `ai models <model>` shows a detail card for any gateway model: context window, max output, pricing (input, output, cache read/write, web search), release date and per-provider latency, throughput and uptime; supports `--json` (#75)
 
 ### Contributors
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "packages/ai-cli": {
       "name": "ai-cli",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "bin": {
         "ai": "./dist/index.js",
       },

--- a/packages/ai-cli/package.json
+++ b/packages/ai-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A tiny, agent-native CLI for generating images, video, audio and text with dead-simple commands, stdin support and predictable artifact outputs",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump and changelog updates for the v0.4.2 release.

- Bumped `ai-cli` version from 0.4.1 to 0.4.2 in `package.json` and `bun.lock`
- Renamed the `Unreleased` changelog section to `0.4.2` and added a PR reference (#75) to the model info feature entry