### PR TITLE
Add --timeout flag to text, image, video, and audio

### DIFF
--- a/apps/web/docs/commands.mdx
+++ b/apps/web/docs/commands.mdx
@@ -28,6 +28,9 @@ ai image "edit this" < photo.png
   <Property name="-p, --concurrency" type="number" default="4">
     Max parallel generations.
   </Property>
+  <Property name="--timeout" type="seconds" default="300">
+    Request timeout in seconds. Must be a positive integer.
+  </Property>
   <Property name="--size" type="WxH">
     Image size (e.g. `1024x1024`). Not supported by Gemini image models — use
     `--aspect-ratio` instead.
@@ -78,6 +81,9 @@ ai image "a dragon" | ai video "animate this"
   <Property name="-p, --concurrency" type="number" default="2">
     Max parallel generations.
   </Property>
+  <Property name="--timeout" type="seconds" default="300">
+    Request timeout in seconds. Must be a positive integer.
+  </Property>
   <Property name="--aspect-ratio" type="W:H">
     Aspect ratio (e.g. `16:9`).
   </Property>
@@ -123,6 +129,9 @@ ai text "summarize this" < notes.txt
   </Property>
   <Property name="-p, --concurrency" type="number" default="4">
     Max parallel generations.
+  </Property>
+  <Property name="--timeout" type="seconds" default="120">
+    Request timeout in seconds. Must be a positive integer.
   </Property>
   <Property name="-s, --system" type="string">
     System prompt.
@@ -183,6 +192,9 @@ cat voice-note.mp3 | ai audio transcribe -o transcript.txt
   <Property name="-p, --concurrency" type="number" default="4">
     Max parallel generations.
   </Property>
+  <Property name="--timeout" type="seconds" default="120">
+    Request timeout in seconds. Must be a positive integer.
+  </Property>
   <Property name="-q, --quiet" type="boolean">
     Suppress progress output.
   </Property>
@@ -221,6 +233,9 @@ cat announcement.txt | ai audio speak --format wav -o announcement.wav
   </Property>
   <Property name="-p, --concurrency" type="number" default="4">
     Max parallel transcriptions.
+  </Property>
+  <Property name="--timeout" type="seconds" default="120">
+    Request timeout in seconds. Must be a positive integer.
   </Property>
   <Property name="-q, --quiet" type="boolean">
     Suppress progress output.
@@ -293,6 +308,12 @@ Requests that exceed the per-command timeout are aborted automatically:
 | `audio transcribe` | 120 seconds |
 
 Image and video generation use a longer timeout because models typically need more processing time.
+
+Use `--timeout <seconds>` to allow a longer request without changing models. The value must be a positive integer:
+
+```bash
+ai image --timeout 600 "a detailed sprite atlas"
+```
 
 ## Exit codes
 

--- a/apps/web/docs/troubleshooting.mdx
+++ b/apps/web/docs/troubleshooting.mdx
@@ -31,7 +31,13 @@ Requests are aborted if they exceed the per-command timeout:
 | `audio speak` | 120 seconds |
 | `audio transcribe` | 120 seconds |
 
-If you're consistently hitting timeouts, try a faster model variant (e.g. `bytedance/seedance-2.0-fast` instead of `bytedance/seedance-2.0`).
+Use `--timeout <seconds>` to allow a longer request without changing models. The value must be a positive integer. For example:
+
+```bash
+ai image --timeout 600 "a detailed sprite atlas"
+```
+
+If you are consistently hitting timeouts, a faster model variant is often the better fix (for example `bytedance/seedance-2.0-fast` instead of `bytedance/seedance-2.0`).
 
 ## `--quality` / `--style` warning
 

--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -45,6 +45,7 @@ All commands support:
 -o, --output <path>      Output file path or directory
 -n, --count <n>          Number of generations per model (default: 1)
 -p, --concurrency <n>    Max parallel generations (default: 4, video: 2)
+--timeout <seconds>      Request timeout in seconds (default: text/audio 120, image/video 300)
 -q, --quiet              Suppress progress output
 --json                   Output metadata as JSON
 ```
@@ -251,6 +252,8 @@ Requests that exceed the timeout are aborted automatically:
 | `video` | 300 seconds |
 | `audio speak` | 120 seconds |
 | `audio transcribe` | 120 seconds |
+
+Use `--timeout <seconds>` to override the default for `text`, `image`, `video`, `audio speak`, or `audio transcribe`. The value must be a positive integer. For example, `ai image --timeout 600 "a detailed sprite atlas"` allows the request to run for up to 10 minutes.
 
 ### Exit Codes
 

--- a/packages/ai-cli/src/cli.test.ts
+++ b/packages/ai-cli/src/cli.test.ts
@@ -213,6 +213,30 @@ describe("cli integration", () => {
     expect(stdout).toContain("--output");
   });
 
+  test.each([
+    [["text"], "120"],
+    [["image"], "300"],
+    [["video"], "300"],
+    [["audio", "speak"], "120"],
+    [["audio", "transcribe"], "120"],
+  ])("%s --help lists --timeout with its default", async (command, seconds) => {
+    const { exitCode, stdout } = await run(...command, "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--timeout");
+    expect(stdout).toContain(`default: ${seconds}`);
+  });
+
+  test("--timeout rejects a value that would overflow the timer", async () => {
+    const { exitCode, stderr } = await run(
+      "image",
+      "--timeout",
+      "3600000",
+      "a prompt"
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("The value is in seconds, not milliseconds.");
+  });
+
   test("audio speak with no text and no stdin exits 1", async () => {
     const { exitCode, stderr } = await run("audio", "speak");
     expect(exitCode).toBe(1);

--- a/packages/ai-cli/src/commands/audio.ts
+++ b/packages/ai-cli/src/commands/audio.ts
@@ -14,6 +14,7 @@ import type { OutputFormat } from "../lib/output.js";
 import { parseNonNegativeFloat, parsePositiveInt } from "../lib/parse.js";
 import { responseIdFromHeaders } from "../lib/response-id.js";
 import { readStdin, stdinAsText } from "../lib/stdin.js";
+import { addTimeoutOption, timeoutMs } from "../lib/timeout.js";
 
 const DEFAULT_CONCURRENCY = 4;
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -41,6 +42,7 @@ interface SpeakOptions {
   json?: boolean;
   play?: boolean;
   waveform?: boolean;
+  timeout: number;
 }
 
 interface TranscribeOptions {
@@ -51,6 +53,7 @@ interface TranscribeOptions {
   concurrency?: string;
   quiet?: boolean;
   json?: boolean;
+  timeout: number;
 }
 
 export function registerAudioCommand(program: Command) {
@@ -58,7 +61,7 @@ export function registerAudioCommand(program: Command) {
     .command("audio")
     .description("Generate speech or transcribe audio");
 
-  audio
+  const speak = audio
     .command("speak")
     .description("Generate speech audio from text")
     .argument("[text]", "Text to convert to speech")
@@ -80,8 +83,9 @@ export function registerAudioCommand(program: Command) {
     .option("-q, --quiet", "Suppress progress output")
     .option("--json", "Output metadata as JSON")
     .option("--no-play", "Disable audio playback after generation")
-    .option("--no-waveform", "Disable accurate terminal waveform preview")
-    .action(async (rawText: string | undefined, opts: SpeakOptions) => {
+    .option("--no-waveform", "Disable accurate terminal waveform preview");
+  addTimeoutOption(speak, DEFAULT_TIMEOUT_MS).action(
+    async (rawText: string | undefined, opts: SpeakOptions) => {
       const text = rawText?.trim() || undefined;
       const stdin = await readStdin();
       const stdinText = stdin ? stdinAsText(stdin).trim() : undefined;
@@ -109,7 +113,7 @@ export function registerAudioCommand(program: Command) {
       const { total, failed } = await runJobs(
         jobs,
         async (modelId) => {
-          const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+          const abort = AbortSignal.timeout(timeoutMs(opts.timeout));
           const result = await generateSpeech({
             headers: gatewayHeaders(),
             model: gateway.speechModel(modelId),
@@ -148,9 +152,10 @@ export function registerAudioCommand(program: Command) {
       );
       if (failed === total) process.exit(1);
       if (failed > 0) process.exit(2);
-    });
+    }
+  );
 
-  audio
+  const transcribeCommand = audio
     .command("transcribe")
     .description("Transcribe audio to text")
     .argument("[audio]", "Audio file path or URL")
@@ -169,8 +174,9 @@ export function registerAudioCommand(program: Command) {
       `Max parallel transcriptions (default: ${DEFAULT_CONCURRENCY})`
     )
     .option("-q, --quiet", "Suppress progress output")
-    .option("--json", "Output metadata as JSON")
-    .action(async (rawAudio: string | undefined, opts: TranscribeOptions) => {
+    .option("--json", "Output metadata as JSON");
+  addTimeoutOption(transcribeCommand, DEFAULT_TIMEOUT_MS).action(
+    async (rawAudio: string | undefined, opts: TranscribeOptions) => {
       const stdin = await readStdin();
       if (!rawAudio && !stdin) {
         process.stderr.write(
@@ -203,7 +209,7 @@ export function registerAudioCommand(program: Command) {
       const { total, failed } = await runJobs(
         jobs,
         async (modelId) => {
-          const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+          const abort = AbortSignal.timeout(timeoutMs(opts.timeout));
           const result = await transcribe({
             headers: gatewayHeaders(),
             model: gateway.transcriptionModel(modelId),
@@ -228,7 +234,8 @@ export function registerAudioCommand(program: Command) {
       );
       if (failed === total) process.exit(1);
       if (failed > 0) process.exit(2);
-    });
+    }
+  );
 }
 
 function buildSpeechText(

--- a/packages/ai-cli/src/commands/image.ts
+++ b/packages/ai-cli/src/commands/image.ts
@@ -11,6 +11,7 @@ import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import { parsePositiveInt, parseSize, parseAspectRatio } from "../lib/parse.js";
 import { responseIdFromHeaders } from "../lib/response-id.js";
 import { readStdin } from "../lib/stdin.js";
+import { addTimeoutOption, timeoutMs } from "../lib/timeout.js";
 
 const DEFAULT_CONCURRENCY = 4;
 const DEFAULT_TIMEOUT_MS = 300_000;
@@ -28,10 +29,11 @@ interface ImageOptions {
   json?: boolean;
   concurrency?: string;
   preview?: boolean;
+  timeout: number;
 }
 
 export function registerImageCommand(program: Command) {
-  program
+  const command = program
     .command("image")
     .description("Generate an image from a prompt")
     .argument("[prompt]", "The prompt to generate an image from")
@@ -60,8 +62,9 @@ export function registerImageCommand(program: Command) {
     .option(
       "-p, --concurrency <n>",
       `Max parallel generations (default: ${DEFAULT_CONCURRENCY})`
-    )
-    .action(async (rawPrompt: string | undefined, opts: ImageOptions) => {
+    );
+  addTimeoutOption(command, DEFAULT_TIMEOUT_MS).action(
+    async (rawPrompt: string | undefined, opts: ImageOptions) => {
       const prompt = rawPrompt?.trim() || undefined;
       const stdin = await readStdin();
       const imageReferenceInputs = opts.image ?? [];
@@ -127,7 +130,7 @@ export function registerImageCommand(program: Command) {
       const { total, failed } = await runJobs(
         jobs,
         async (modelId) => {
-          const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+          const abort = AbortSignal.timeout(timeoutMs(opts.timeout));
 
           if (gatewayModels.languageImageModelIds.has(modelId)) {
             const messageContent: Array<
@@ -215,7 +218,8 @@ export function registerImageCommand(program: Command) {
       );
       if (failed === total) process.exit(1);
       if (failed > 0) process.exit(2);
-    });
+    }
+  );
 }
 
 export function languageImageProviderOptions(

--- a/packages/ai-cli/src/commands/text.ts
+++ b/packages/ai-cli/src/commands/text.ts
@@ -18,6 +18,7 @@ import { fetchGatewayModels, resolveModels } from "../lib/models.js";
 import type { OutputFormat } from "../lib/output.js";
 import { parsePositiveInt, parseTemperature } from "../lib/parse.js";
 import { readStdin, stdinAsText } from "../lib/stdin.js";
+import { addTimeoutOption, timeoutMs } from "../lib/timeout.js";
 
 const DEFAULT_CONCURRENCY = 4;
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -34,6 +35,7 @@ interface TextOptions {
   concurrency?: string;
   quiet?: boolean;
   json?: boolean;
+  timeout: number;
 }
 
 type TextPrompt = string | ModelMessage[];
@@ -45,7 +47,7 @@ function resolveFormat(fmt?: string): OutputFormat {
 }
 
 export function registerTextCommand(program: Command) {
-  program
+  const command = program
     .command("text")
     .description("Generate text from a prompt")
     .argument("[prompt]", "The prompt to generate text from")
@@ -70,8 +72,9 @@ export function registerTextCommand(program: Command) {
     .option("--max-tokens <n>", "Maximum tokens to generate")
     .option("-t, --temperature <n>", "Temperature (0-2)")
     .option("-q, --quiet", "Suppress progress output")
-    .option("--json", "Output metadata as JSON")
-    .action(async (rawPrompt: string | undefined, opts: TextOptions) => {
+    .option("--json", "Output metadata as JSON");
+  addTimeoutOption(command, DEFAULT_TIMEOUT_MS).action(
+    async (rawPrompt: string | undefined, opts: TextOptions) => {
       const prompt = rawPrompt?.trim() || undefined;
       const stdin = await readStdin();
       const imageReferenceInputs = opts.image ?? [];
@@ -118,7 +121,7 @@ export function registerTextCommand(program: Command) {
       const { total, failed } = await runJobs(
         jobs,
         async (modelId) => {
-          const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+          const abort = AbortSignal.timeout(timeoutMs(opts.timeout));
           const result = await generateText({
             headers: {
               "http-referer": "https://github.com/vercel-labs/ai-cli",
@@ -146,7 +149,8 @@ export function registerTextCommand(program: Command) {
       );
       if (failed === total) process.exit(1);
       if (failed > 0) process.exit(2);
-    });
+    }
+  );
 }
 
 function buildTextPrompt({

--- a/packages/ai-cli/src/commands/video.ts
+++ b/packages/ai-cli/src/commands/video.ts
@@ -15,6 +15,7 @@ import {
 } from "../lib/parse.js";
 import { responseIdFromHeaders } from "../lib/response-id.js";
 import { readStdin } from "../lib/stdin.js";
+import { addTimeoutOption, timeoutMs } from "../lib/timeout.js";
 
 const DEFAULT_CONCURRENCY = 2;
 const DEFAULT_TIMEOUT_MS = 300_000;
@@ -30,10 +31,11 @@ interface VideoOptions {
   json?: boolean;
   concurrency?: string;
   preview?: boolean;
+  timeout: number;
 }
 
 export function registerVideoCommand(program: Command) {
-  program
+  const command = program
     .command("video")
     .description("Generate a video from a prompt")
     .argument("[prompt]", "The prompt to generate a video from")
@@ -60,8 +62,9 @@ export function registerVideoCommand(program: Command) {
     .option(
       "-p, --concurrency <n>",
       `Max parallel generations (default: ${DEFAULT_CONCURRENCY})`
-    )
-    .action(async (rawPrompt: string | undefined, opts: VideoOptions) => {
+    );
+  addTimeoutOption(command, DEFAULT_TIMEOUT_MS).action(
+    async (rawPrompt: string | undefined, opts: VideoOptions) => {
       const prompt = rawPrompt?.trim() || undefined;
       const stdin = await readStdin();
       const imageReferenceInputs = opts.image ?? [];
@@ -117,7 +120,7 @@ export function registerVideoCommand(program: Command) {
       const { total, failed } = await runJobs(
         jobs,
         async (modelId) => {
-          const abort = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+          const abort = AbortSignal.timeout(timeoutMs(opts.timeout));
           const result = await generateVideo({
             headers: {
               "http-referer": "https://github.com/vercel-labs/ai-cli",
@@ -148,5 +151,6 @@ export function registerVideoCommand(program: Command) {
       );
       if (failed === total) process.exit(1);
       if (failed > 0) process.exit(2);
-    });
+    }
+  );
 }

--- a/packages/ai-cli/src/lib/timeout.test.ts
+++ b/packages/ai-cli/src/lib/timeout.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import { Command } from "./command.js";
+import { addTimeoutOption, timeoutMs } from "./timeout.js";
+
+async function parseTimeout(args: string[]): Promise<number | undefined> {
+  let timeout: number | undefined;
+  const program = new Command().name("ai");
+  addTimeoutOption(
+    program.command("image").action((_argument, options) => {
+      timeout = (options as { timeout: number }).timeout;
+    }),
+    300_000
+  );
+
+  await program.parseAsync(["node", "ai", "image", ...args]);
+  return timeout;
+}
+
+describe("timeout option", () => {
+  test("parses seconds", async () => {
+    expect(await parseTimeout(["--timeout", "600"])).toBe(600);
+  });
+
+  test("applies the command default when absent", async () => {
+    expect(await parseTimeout([])).toBe(300);
+  });
+
+  test.each(["abc", "0", "-1"])("rejects invalid value %s", async (value) => {
+    await expect(parseTimeout(["--timeout", value])).rejects.toThrow(
+      `--timeout must be a positive integer, got "${value}"`
+    );
+  });
+
+  test("accepts the largest delay a 32-bit timer can hold", async () => {
+    expect(await parseTimeout(["--timeout", "2147483"])).toBe(2_147_483);
+  });
+
+  test.each(["2147484", "3600000", "4294968"])(
+    "rejects %s seconds, which would overflow the timer",
+    async (value) => {
+      await expect(parseTimeout(["--timeout", value])).rejects.toThrow(
+        "The value is in seconds, not milliseconds."
+      );
+    }
+  );
+});
+
+describe("timeoutMs", () => {
+  test("converts seconds to milliseconds", () => {
+    expect(timeoutMs(600)).toBe(600_000);
+  });
+
+  test("keeps the largest accepted timeout inside a 32-bit signed integer", () => {
+    expect(timeoutMs(2_147_483)).toBeLessThanOrEqual(2_147_483_647);
+  });
+});

--- a/packages/ai-cli/src/lib/timeout.ts
+++ b/packages/ai-cli/src/lib/timeout.ts
@@ -1,0 +1,32 @@
+import type { Command } from "./command.js";
+import { parsePositiveInt } from "./parse.js";
+
+// AbortSignal.timeout is backed by a 32-bit timer under Node, so a larger delay
+// fires after 1ms instead of the requested duration.
+const MAX_TIMEOUT_SECONDS = Math.floor(2_147_483_647 / 1000);
+
+export function parseTimeoutSeconds(value: string): number {
+  const seconds = parsePositiveInt(value, "timeout");
+  if (seconds > MAX_TIMEOUT_SECONDS) {
+    throw new Error(
+      `--timeout must be at most ${MAX_TIMEOUT_SECONDS} seconds, got "${value}". The value is in seconds, not milliseconds.`
+    );
+  }
+  return seconds;
+}
+
+export function addTimeoutOption(
+  command: Command,
+  defaultTimeoutMs: number
+): Command {
+  return command.option(
+    "--timeout <seconds>",
+    "Request timeout in seconds",
+    (value) => parseTimeoutSeconds(value),
+    defaultTimeoutMs / 1000
+  );
+}
+
+export function timeoutMs(seconds: number): number {
+  return seconds * 1000;
+}

--- a/skills/ai-cli/SKILL.md
+++ b/skills/ai-cli/SKILL.md
@@ -40,6 +40,7 @@ ai models --type audio                   # list speech and transcription models
 -n, --count <n>        Number of generations per model
 -q, --quiet            Suppress progress output
 --json                 Output structured metadata as JSON (paths, timing, success/failure)
+--timeout <seconds>    Request timeout in seconds (see Timeouts for per-command defaults)
 ```
 
 ## Piping Patterns
@@ -110,6 +111,14 @@ When the CLI chooses a filename, it uses a response ID when available and falls 
 - video: 300 seconds
 - audio speak: 120 seconds
 - audio transcribe: 120 seconds
+
+Override with `--timeout <seconds>` when a prompt legitimately needs longer, instead of dropping to a faster model variant that changes the output:
+
+```bash
+ai image "a 72-cell sprite atlas, detailed" --timeout 600
+```
+
+The value is in seconds, not milliseconds, and is capped at 2147483.
 
 ## Exit Codes
 


### PR DESCRIPTION
Closes #78.

Every command hardcoded its abort timeout, so a request that legitimately needed longer could not be run at all. The only workaround was switching to a faster model variant, which changes the output instead of giving the original request more time. The case that surfaced it was a 72-cell sprite atlas exceeding the image default.

## What changed

`--timeout <seconds>` on `text`, `image`, `video`, `audio speak`, and `audio transcribe`. It defaults to each command's existing value, so behavior is unchanged when the flag is absent. All six `AbortSignal.timeout` call sites are covered, including both in `audio.ts`.

Wired through a small `addTimeoutOption` helper so the flag is declared once and every command gets identical parsing, validation, and help text.

## The upper bound

The value is rejected above 2147483 seconds. `AbortSignal.timeout` is backed by a 32-bit timer under Node, which is what ships (`#!/usr/bin/env node`, `engines.node >= 22`):

```
--timeout 3600000  -> 3600000000 ms -> aborted after 52ms
   TimeoutOverflowWarning: 3600000000 does not fit into a 32-bit signed integer.
   Timeout duration was set to 1.
--timeout 4294968  -> RangeError: The value of "delay" is out of range.
```

A user who assumes the unit is milliseconds and passes `--timeout 3600000` for "one hour" would ask for a longer timeout and get an instant abort that reads as a model failure. Rejecting beats clamping: the error names the unit and corrects the mental model, where a clamp would silently hand back a 24-day timeout.

Worth flagging for reviewers: this class of bug is invisible to `bun test`. Under Bun the same delay stays pending up to 2^53-1, so the boundary was verified against Node v24 directly. `2147483` survives with no warning, `2147484` is rejected.

## Docs

The flag is documented in `README.md`, `apps/web/docs/commands.mdx`, and `apps/web/docs/troubleshooting.mdx`. In troubleshooting it sits alongside the existing faster-model-variant advice rather than replacing it, since neither makes the other obsolete.

No CHANGELOG entry, since that section is written by the release-prep PR.

## Verification

```
bun test    171 pass, 0 fail  (159 before)
typecheck   pass
lint        pass
format      pass
```

New tests cover the parse boundary, the seconds-to-milliseconds conversion, and, in `cli.test.ts`, that all five leaf commands actually expose the flag with the right default. That last one matters: without it, deleting `addTimeoutOption` from a command would leave the suite fully green.
