### PR TITLE
fix: validate model IDs before gateway requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- **Invalid model ID errors** - model IDs containing Unicode characters or spaces now fail immediately with an actionable validation error instead of being retried and reported as an invalid AI Gateway response
+
 ## 0.4.2
 
 <!-- release:start -->

--- a/apps/web/docs/models.mdx
+++ b/apps/web/docs/models.mdx
@@ -36,6 +36,8 @@ ai image -m flux-2-pro "a sunset"
 ai audio speak -m tts-1 "hello"
 ```
 
+Model IDs must contain printable ASCII characters without spaces. This applies to both `--model` values and the `AI_CLI_*_MODEL` environment variables. Invalid values are rejected before a request is sent.
+
 ## Multi-model comparison
 
 Generate with multiple models by comma-separating `-m`:

--- a/apps/web/docs/troubleshooting.mdx
+++ b/apps/web/docs/troubleshooting.mdx
@@ -19,6 +19,14 @@ export OPENAI_API_KEY="sk-..."         # OpenAI models only
 
 Add the export to your shell profile (`~/.zshrc`, `~/.bashrc`) to persist across sessions.
 
+## Invalid model ID
+
+```
+Error: model ID must use printable ASCII characters without spaces
+```
+
+AI Gateway model IDs are sent as HTTP request metadata and use forms such as `openai/gpt-5.5`. Check the value passed to `--model` and any `AI_CLI_*_MODEL` environment variable for Unicode characters or embedded spaces.
+
 ## Timeout errors
 
 Requests are aborted if they exceed the per-command timeout:

--- a/packages/ai-cli/README.md
+++ b/packages/ai-cli/README.md
@@ -60,6 +60,8 @@ ai image -m flux-2-pro "a sunset"   # resolves to bfl/flux-2-pro
 ai audio speak -m tts-1 "hello"     # resolves to openai/tts-1
 ```
 
+Model IDs must contain printable ASCII characters without spaces. This applies to both `--model` values and the `AI_CLI_*_MODEL` environment variables.
+
 ### image
 
 ```

--- a/packages/ai-cli/src/lib/models.test.ts
+++ b/packages/ai-cli/src/lib/models.test.ts
@@ -64,6 +64,18 @@ describe("resolveModels", () => {
       "nonexistent",
     ]);
   });
+
+  test("rejects non-ASCII model IDs before they become request headers", () => {
+    expect(() => resolveModels("text", "𝕏")).toThrow(
+      'model ID must use printable ASCII characters without spaces (got "𝕏")'
+    );
+  });
+
+  test("rejects spaces inside model IDs", () => {
+    expect(() => resolveModels("text", "openai/gpt 5")).toThrow(
+      'model ID must use printable ASCII characters without spaces (got "openai/gpt 5")'
+    );
+  });
 });
 
 describe("resolveModels multi", () => {

--- a/packages/ai-cli/src/lib/models.ts
+++ b/packages/ai-cli/src/lib/models.ts
@@ -230,13 +230,24 @@ export function resolveModels(
   userModel?: string,
   knownModels?: Pick<ModelEntry, "id">[]
 ): string[] {
-  if (!userModel) return [DEFAULTS[modality]];
+  if (!userModel) return [validateModelId(DEFAULTS[modality])];
   const models = userModel
     .split(",")
     .map((m) => m.trim())
     .filter(Boolean)
-    .map((m) => expandModelId(m, knownModels));
-  return models.length > 0 ? models : [DEFAULTS[modality]];
+    .map((m) => validateModelId(expandModelId(m, knownModels)));
+  return models.length > 0 ? models : [validateModelId(DEFAULTS[modality])];
+}
+
+function validateModelId(modelId: string): string {
+  // The Gateway SDK sends model IDs in an HTTP header. Validate before the SDK
+  // turns an invalid header value into a retried GatewayResponseError.
+  if (!/^[\x21-\x7e]+$/.test(modelId)) {
+    throw new Error(
+      `model ID must use printable ASCII characters without spaces (got ${JSON.stringify(modelId)})`
+    );
+  }
+  return modelId;
 }
 
 export function expandModelId(


### PR DESCRIPTION
- Reject Unicode and embedded spaces before SDK header construction.
- Add regression coverage and document valid model ID formatting.