### PR TITLE
Prepare v0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,27 @@
 # Changelog
 
-## Unreleased
+## 0.4.3
+
+<!-- release:start -->
+
+### New Features
+
+- **Configurable request timeouts** - `--timeout <seconds>` lets text, image, video and audio requests run longer than their per-command defaults, with validation for invalid or overflowing values (#79)
+
+### Improvements
+
+- **Leaner CLI runtime** - replaced the Commander dependency with a focused local argument parser while preserving existing CLI behavior (#77)
 
 ### Bug Fixes
 
-- **Invalid model ID errors** - model IDs containing Unicode characters or spaces now fail immediately with an actionable validation error instead of being retried and reported as an invalid AI Gateway response
+- **Invalid model ID errors** - model IDs containing Unicode characters or spaces now fail immediately with an actionable validation error instead of being retried and reported as an invalid AI Gateway response (#80)
+
+### Contributors
+
+- @Railly
+- @ctate
+
+<!-- release:end -->
 
 ## 0.4.2
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "packages/ai-cli": {
       "name": "ai-cli",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "bin": {
         "ai": "./dist/index.js",
       },

--- a/packages/ai-cli/package.json
+++ b/packages/ai-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A tiny, agent-native CLI for generating images, video, audio and text with dead-simple commands, stdin support and predictable artifact outputs",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Bump ai-cli package and lockfile metadata to v0.4.3.
- Add release notes for parser, timeout, and model validation changes.