### PR TITLE
fix(web): preserve social link previews

### DIFF
--- a/apps/web/lib/agent-readability.test.ts
+++ b/apps/web/lib/agent-readability.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldServeMarkdown } from "@vercel/agent-readability";
+
+describe("agent readability", () => {
+	test.each([
+		"Slackbot-LinkExpanding 1.0",
+		"Discordbot/2.0",
+		"redditbot/1.0",
+		"bitlybot/3.0",
+		"Pinterestbot/1.0",
+	])("keeps %s on HTML", (userAgent) => {
+		const result = shouldServeMarkdown({
+			headers: new Headers({ "user-agent": userAgent }),
+		});
+
+		expect(result.serve).toBeFalse();
+	});
+
+	test("still detects agents", () => {
+		const result = shouldServeMarkdown({
+			headers: new Headers({ "user-agent": "ClaudeBot/1.0" }),
+		});
+
+		expect(result.serve).toBeTrue();
+	});
+});

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,25 +1,13 @@
 import { withAgentReadability } from "@vercel/agent-readability/next";
-import type { NextFetchEvent, NextRequest } from "next/server";
-import { NextResponse } from "next/server";
 
-const PREVIEW_BOTS = /slackbot|discordbot/i;
-
-const agentMarkdown = withAgentReadability({
-  docsPrefix: "/",
-  rewrite: (pathname) =>
-    pathname === "/" ? "/api/docs-md" : `/api/docs-md${pathname}`,
-  canonicalUrl: () => null,
+export default withAgentReadability({
+	docsPrefix: "/",
+	rewrite: (pathname) =>
+		pathname === "/" ? "/api/docs-md" : `/api/docs-md${pathname}`,
+	canonicalUrl: () => null,
 });
 
-export default function middleware(req: NextRequest, event: NextFetchEvent) {
-  const ua = req.headers.get("user-agent") ?? "";
-  if (PREVIEW_BOTS.test(ua)) {
-    return NextResponse.next();
-  }
-  return agentMarkdown(req, event);
-}
-
 export const config = {
-  matcher:
-    "/((?!_next|api|og|.*\\..*|favicon|manifest|robots|health|status).*)",
+	matcher:
+		"/((?!_next|api|og|.*\\..*|favicon|manifest|robots|health|status).*)",
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@vercel/agent-readability": "0.5.0",
+    "@vercel/agent-readability": "0.5.1",
     "fromsrc": "0.0.23",
     "geist": "^1.4.0",
     "next": "16.2.1",

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
       "name": "@ai-cli/web",
       "version": "0.0.0",
       "dependencies": {
-        "@vercel/agent-readability": "0.5.0",
+        "@vercel/agent-readability": "0.5.1",
         "fromsrc": "0.0.23",
         "geist": "^1.4.0",
         "next": "16.2.1",
@@ -345,7 +345,7 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@vercel/agent-readability": ["@vercel/agent-readability@0.5.0", "", { "peerDependencies": { "@sveltejs/kit": ">=2", "@vercel/functions": "^3", "h3": ">=1.8 <2", "next": ">=14" }, "optionalPeers": ["@sveltejs/kit", "@vercel/functions", "h3", "next"], "bin": { "agent-readability": "dist/cli/index.cjs" } }, "sha512-ZY2i+p2/YCu4kAMGeGCq7Dn22XFWmLwQ1+sa2PrvWdeGCKqcx+CNp+4RF022QI+/e8RgPRjwQurjpmafiZlhTA=="],
+    "@vercel/agent-readability": ["@vercel/agent-readability@0.5.1", "", { "peerDependencies": { "@sveltejs/kit": ">=2", "@vercel/functions": "^3", "h3": ">=1.8 <2", "next": ">=14" }, "optionalPeers": ["@sveltejs/kit", "@vercel/functions", "h3", "next"], "bin": { "agent-readability": "dist/cli/index.cjs" } }, "sha512-iQih444RJMoAREej/ccTmAUc+PiSogRffqQZMvGdcfF/5GN/4VilXrMHYQWRIq75c70D2AIOxX5sh9EG23ZT3w=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 


### PR DESCRIPTION
## Summary

- upgrade `@vercel/agent-readability` to `0.5.1`
- remove the incomplete local Slack and Discord bypass
- preserve HTML previews for Slack, Discord, Reddit, Bitly, and Pinterest while keeping ClaudeBot on Markdown

## Verification

- `bun install --frozen-lockfile`
- `bun test apps/web/lib/agent-readability.test.ts`
- `bun run typecheck`
- `bun run --cwd apps/web build`
- production server UA matrix
